### PR TITLE
GitHub授权登录的kiro协议问题

### DIFF
--- a/src-tauri/src/commands/app_settings_cmd.rs
+++ b/src-tauri/src/commands/app_settings_cmd.rs
@@ -202,6 +202,114 @@ pub fn get_browser_path() -> Option<String> {
         .filter(|p| !p.is_empty())
 }
 
+#[cfg(windows)]
+fn write_protocol_mapping(exe_path: &str) -> Result<String, String> {
+    use std::path::Path;
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
+    let normalized = exe_path.trim().trim_matches('"');
+    if normalized.is_empty() {
+        return Err("协议映射路径不能为空".to_string());
+    }
+    if !Path::new(normalized).exists() {
+        return Err(format!("目标文件不存在: {normalized}"));
+    }
+
+    let command = format!("\"{normalized}\" \"%1\"");
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    for scheme in ["kiro", "kiro-account-manager"] {
+        let class_path = format!("Software\\Classes\\{scheme}");
+        let (class_key, _) = hkcu
+            .create_subkey(&class_path)
+            .map_err(|e| format!("创建协议键失败（{scheme}）: {e}"))?;
+        class_key
+            .set_value("", &format!("URL:{scheme} Protocol"))
+            .map_err(|e| format!("设置协议标题失败（{scheme}）: {e}"))?;
+        class_key
+            .set_value("URL Protocol", &"")
+            .map_err(|e| format!("设置 URL Protocol 失败（{scheme}）: {e}"))?;
+
+        let (cmd_key, _) = hkcu
+            .create_subkey(format!("{class_path}\\shell\\open\\command"))
+            .map_err(|e| format!("创建命令键失败（{scheme}）: {e}"))?;
+        cmd_key
+            .set_value("", &command)
+            .map_err(|e| format!("写入命令失败（{scheme}）: {e}"))?;
+    }
+
+    Ok(command)
+}
+
+#[cfg(windows)]
+fn get_protocol_command_inner() -> Result<String, String> {
+    use winreg::enums::{HKEY_CLASSES_ROOT, HKEY_CURRENT_USER};
+    use winreg::RegKey;
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    if let Ok(cmd_key) = hkcu.open_subkey("Software\\Classes\\kiro\\shell\\open\\command") {
+        let command: String = cmd_key.get_value("").unwrap_or_default();
+        if !command.trim().is_empty() {
+            return Ok(command);
+        }
+    }
+
+    let hkcr = RegKey::predef(HKEY_CLASSES_ROOT);
+    if let Ok(cmd_key) = hkcr.open_subkey("kiro\\shell\\open\\command") {
+        let command: String = cmd_key.get_value("").unwrap_or_default();
+        if !command.trim().is_empty() {
+            return Ok(command);
+        }
+    }
+
+    Err("未找到 kiro 协议映射".to_string())
+}
+
+#[cfg(not(windows))]
+fn get_protocol_command_inner() -> Result<String, String> {
+    Err("当前平台不支持 kiro 协议映射设置".to_string())
+}
+
+#[tauri::command]
+pub async fn get_kiro_protocol_command() -> Result<String, String> {
+    run_blocking_io(get_protocol_command_inner).await
+}
+
+#[tauri::command]
+pub async fn set_kiro_protocol_executable(path: String) -> Result<String, String> {
+    run_blocking_io(move || {
+        #[cfg(windows)]
+        {
+            write_protocol_mapping(&path)
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = path;
+            Err("当前平台不支持 kiro 协议映射设置".to_string())
+        }
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn reset_kiro_protocol_to_current_exe() -> Result<String, String> {
+    run_blocking_io(|| {
+        #[cfg(windows)]
+        {
+            let exe_path = std::env::current_exe()
+                .map_err(|e| format!("无法获取当前程序路径: {e}"))?
+                .display()
+                .to_string();
+            write_protocol_mapping(&exe_path)
+        }
+        #[cfg(not(windows))]
+        {
+            Err("当前平台不支持 kiro 协议映射设置".to_string())
+        }
+    })
+    .await
+}
+
 // ============================================================
 // 账号绑定机器码功能（已废弃，保留空实现兼容旧调用）
 // ============================================================

--- a/src-tauri/src/commands/auth_cmd.rs
+++ b/src-tauri/src/commands/auth_cmd.rs
@@ -17,6 +17,41 @@ use crate::state::AppState;
 use std::sync::{Mutex, MutexGuard};
 use tauri::{Emitter, State};
 
+#[cfg(windows)]
+fn ensure_kiro_protocol_points_to_current_app() -> Result<(), String> {
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
+    let exe_path = std::env::current_exe()
+        .map_err(|e| format!("Failed to resolve current exe path: {e}"))?
+        .display()
+        .to_string();
+    let command = format!("\"{exe_path}\" \"%1\"");
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+
+    for scheme in ["kiro", "kiro-account-manager"] {
+        let class_path = format!("Software\\Classes\\{scheme}");
+        let (class_key, _) = hkcu
+            .create_subkey(&class_path)
+            .map_err(|e| format!("Failed to create protocol key `{scheme}`: {e}"))?;
+        class_key
+            .set_value("", &format!("URL:{scheme} Protocol"))
+            .map_err(|e| format!("Failed to set protocol title `{scheme}`: {e}"))?;
+        class_key
+            .set_value("URL Protocol", &"")
+            .map_err(|e| format!("Failed to set URL Protocol flag `{scheme}`: {e}"))?;
+
+        let (cmd_key, _) = hkcu
+            .create_subkey(format!("{class_path}\\shell\\open\\command"))
+            .map_err(|e| format!("Failed to create command key `{scheme}`: {e}"))?;
+        cmd_key
+            .set_value("", &command)
+            .map_err(|e| format!("Failed to set protocol command `{scheme}`: {e}"))?;
+    }
+
+    Ok(())
+}
+
 fn lock_state<'a, T>(mutex: &'a Mutex<T>, label: &str) -> Result<MutexGuard<'a, T>, String> {
     mutex
         .lock()
@@ -51,7 +86,6 @@ fn resolve_idc_login_email(
 
 fn social_callback_redirect_uri() -> String {
     crate::core::deep_link_handler::DeepLinkCallbackWaiter::get_redirect_uri()
-        .replace("/authenticate-success", "/app/callback")
 }
 
 fn prepare_pending_social_login(provider: &str, machineid: String) -> crate::state::PendingLogin {
@@ -137,6 +171,9 @@ async fn login_social(
     state: State<'_, AppState>,
     config: &crate::auth::providers::ProviderConfig,
 ) -> Result<String, String> {
+    #[cfg(windows)]
+    ensure_kiro_protocol_points_to_current_app()?;
+
     let provider_id = config.provider_id.clone();
     let pending = prepare_pending_social_login(&provider_id, get_machine_id());
     let redirect_uri = social_callback_redirect_uri();
@@ -445,10 +482,10 @@ mod tests {
     }
 
     #[test]
-    fn social_callback_redirect_uri_uses_app_callback_path() {
+    fn social_callback_redirect_uri_uses_compat_callback_path() {
         let redirect_uri = social_callback_redirect_uri();
 
-        assert!(redirect_uri.starts_with("kiro-account-manager://"));
-        assert!(redirect_uri.ends_with("/app/callback"));
+        assert!(redirect_uri.starts_with("kiro://"));
+        assert!(redirect_uri.ends_with("/authenticate-success"));
     }
 }

--- a/src-tauri/src/core/deep_link_handler.rs
+++ b/src-tauri/src/core/deep_link_handler.rs
@@ -1,12 +1,12 @@
 // Deep Link 回调处理
-// 处理 kiro-account-manager://kiro.kiroAgent/authenticate-success?code=xxx&state=xxx 格式的 OAuth 回调
+// 处理 kiro://kiro.kiroAgent/authenticate-success?code=xxx&state=xxx 格式的 OAuth 回调
 
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-const DEEP_LINK_SCHEME: &str = "kiro-account-manager";
-const DEEP_LINK_REDIRECT_URI: &str = "kiro-account-manager://kiro.kiroAgent/authenticate-success";
+const DEEP_LINK_SCHEME: &str = "kiro";
+const DEEP_LINK_REDIRECT_URI: &str = "kiro://kiro.kiroAgent/authenticate-success";
 
 /// OAuth 回调结果（state 已在 `handle_deep_link` 中验证）
 #[derive(Debug, Clone)]
@@ -93,7 +93,7 @@ pub fn cancel_waiter() -> bool {
     true
 }
 
-/// 将 deep link 中的 `/app/callback` 映射到应用内的 `/callback`
+/// 将 deep link 中的 OAuth 回调路径映射到应用内的 `/callback`
 pub fn get_app_callback_route(url: &str) -> Option<String> {
     let parsed = url::Url::parse(url).ok()?;
 
@@ -101,7 +101,7 @@ pub fn get_app_callback_route(url: &str) -> Option<String> {
         return None;
     }
 
-    if parsed.path() != "/app/callback" {
+    if parsed.path() != "/app/callback" && parsed.path() != "/authenticate-success" {
         return None;
     }
 
@@ -224,7 +224,7 @@ mod tests {
         ));
 
         let handled =
-            handle_deep_link("kiro-account-manager://kiro.kiroAgent/authenticate-success?code=ok&state=expected-state");
+            handle_deep_link("kiro://kiro.kiroAgent/authenticate-success?code=ok&state=expected-state");
         assert!(handled);
         assert_eq!(
             waiter
@@ -238,7 +238,7 @@ mod tests {
     #[test]
     fn app_callback_deep_link_maps_to_internal_callback_route() {
         let route = get_app_callback_route(
-            "kiro-account-manager://kiro.kiroAgent/app/callback?code=ok&state=expected-state",
+            "kiro://kiro.kiroAgent/app/callback?code=ok&state=expected-state",
         )
         .expect("app callback route should be extracted");
 
@@ -246,12 +246,12 @@ mod tests {
     }
 
     #[test]
-    fn authenticate_success_deep_link_does_not_map_to_internal_callback_route() {
-        assert!(
-            get_app_callback_route(
-                "kiro-account-manager://kiro.kiroAgent/authenticate-success?code=ok&state=expected-state",
-            )
-            .is_none()
-        );
+    fn authenticate_success_deep_link_maps_to_internal_callback_route() {
+        let route = get_app_callback_route(
+            "kiro://kiro.kiroAgent/authenticate-success?code=ok&state=expected-state",
+        )
+        .expect("authenticate-success callback route should be extracted");
+
+        assert_eq!(route, "/callback?code=ok&state=expected-state");
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,7 +30,9 @@ use commands::account_cmd::{
 };
 use commands::app_settings_cmd::{
     bind_machine_id_to_account, get_all_bound_machine_ids, get_app_settings, get_bound_machine_id,
-    get_usage_history, save_app_settings, save_usage_history_entry, unbind_machine_id_from_account,
+    get_kiro_protocol_command, get_usage_history, reset_kiro_protocol_to_current_exe,
+    save_app_settings, save_usage_history_entry, set_kiro_protocol_executable,
+    unbind_machine_id_from_account,
 };
 use commands::auth_cmd::{
     cancel_kiro_login, get_current_user, get_supported_providers, handle_kiro_social_callback,
@@ -89,6 +91,70 @@ use kiro::ide::{
     check_ide_installation, get_kiro_local_token, read_kiro_accounts, switch_kiro_account,
 };
 use kiro::process::{close_kiro_ide, is_kiro_ide_running, start_kiro_ide};
+
+const COMPAT_DEEP_LINK_SCHEMES: [&str; 2] = ["kiro", "kiro-account-manager"];
+
+fn is_supported_deep_link(url: &str) -> bool {
+    COMPAT_DEEP_LINK_SCHEMES
+        .iter()
+        .any(|scheme| url.starts_with(&format!("{scheme}://")))
+}
+
+#[cfg(windows)]
+fn ensure_windows_protocol_association() -> Result<(), String> {
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
+    fn extract_executable(command: &str) -> Option<String> {
+        let trimmed = command.trim();
+        if let Some(rest) = trimmed.strip_prefix('"') {
+            let end = rest.find('"')?;
+            return Some(rest[..end].to_string());
+        }
+        trimmed.split_whitespace().next().map(ToString::to_string)
+    }
+
+    let exe_path = std::env::current_exe()
+        .map_err(|e| format!("Failed to resolve current exe path: {e}"))?
+        .display()
+        .to_string();
+    let command = format!("\"{exe_path}\" \"%1\"");
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    for scheme in COMPAT_DEEP_LINK_SCHEMES {
+        let class_path = format!("Software\\Classes\\{scheme}");
+        let (class_key, _) = hkcu
+            .create_subkey(&class_path)
+            .map_err(|e| format!("Failed to create protocol key `{scheme}`: {e}"))?;
+        class_key
+            .set_value("", &format!("URL:{scheme} Protocol"))
+            .map_err(|e| format!("Failed to set protocol title `{scheme}`: {e}"))?;
+        class_key
+            .set_value("URL Protocol", &"")
+            .map_err(|e| format!("Failed to set URL Protocol flag `{scheme}`: {e}"))?;
+
+        let (cmd_key, _) = hkcu
+            .create_subkey(format!("{class_path}\\shell\\open\\command"))
+            .map_err(|e| format!("Failed to create command key `{scheme}`: {e}"))?;
+        let existing_command: String = cmd_key.get_value("").unwrap_or_default();
+        let should_repair = match extract_executable(&existing_command) {
+            Some(existing_exe) => {
+                let existing_lower = existing_exe.to_ascii_lowercase();
+                existing_lower.contains("electron.exe")
+                    || !std::path::Path::new(&existing_exe).exists()
+            }
+            None => true,
+        };
+
+        if should_repair {
+            cmd_key
+                .set_value("", &command)
+                .map_err(|e| format!("Failed to set protocol command `{scheme}`: {e}"))?;
+        }
+    }
+
+    Ok(())
+}
 
 /// 配置日志插件
 fn setup_log_plugin() -> tauri_plugin_log::Builder {
@@ -152,12 +218,8 @@ fn handle_incoming_deep_link(app_handle: &tauri::AppHandle, url: &str) {
 #[allow(clippy::needless_pass_by_value)] // Tauri 框架要求回调签名为 Vec<String>
 fn setup_single_instance_callback(app: &tauri::AppHandle, argv: Vec<String>, _cwd: String) {
     // 当第二个实例尝试启动时，处理传入的参数（deep-link 回调）
-    let protocol_prefix = format!(
-        "{}://",
-        core::deep_link_handler::DeepLinkCallbackWaiter::get_protocol_scheme()
-    );
     for arg in &argv {
-        if arg.starts_with(&protocol_prefix) {
+        if is_supported_deep_link(arg) {
             handle_incoming_deep_link(app, arg);
         }
     }
@@ -179,12 +241,8 @@ fn handle_deep_link_event(app_handle: &tauri::AppHandle, payload: &str) {
         payload.to_string()
     };
 
-    // 只处理当前环境的协议
-    let protocol_prefix = format!(
-        "{}://",
-        core::deep_link_handler::DeepLinkCallbackWaiter::get_protocol_scheme()
-    );
-    if !url.starts_with(&protocol_prefix) {
+    // 只处理支持的协议（兼容历史版本）
+    if !is_supported_deep_link(&url) {
         return;
     }
 
@@ -193,25 +251,35 @@ fn handle_deep_link_event(app_handle: &tauri::AppHandle, payload: &str) {
 
 /// 应用 setup 回调
 fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(windows)]
+    if let Err(err) = ensure_windows_protocol_association() {
+        log::warn!("Failed to repair deep-link protocol association: {err}");
+    }
+
     // 首次启动时检查命令行参数中的 deep link（Windows/Linux）
-    let protocol_prefix = format!(
-        "{}://",
-        core::deep_link_handler::DeepLinkCallbackWaiter::get_protocol_scheme()
-    );
     for arg in std::env::args() {
-        if arg.starts_with(&protocol_prefix) {
+        if is_supported_deep_link(&arg) {
             handle_incoming_deep_link(app.handle(), &arg);
         }
     }
 
-    // 监听 deep link 事件（根据环境自动选择协议）
-    #[cfg(any(target_os = "linux", all(debug_assertions, windows)))]
+    // 监听 deep link 事件（Windows/Linux 下都尝试注册，避免旧协议关联残留）
+    #[cfg(any(target_os = "linux", windows))]
     {
         use tauri_plugin_deep_link::DeepLinkExt;
-        let scheme = core::deep_link_handler::DeepLinkCallbackWaiter::get_protocol_scheme();
-        app.deep_link()
-            .register(scheme)
-            .map_err(|e| format!("Failed to register deep link: {e}"))?;
+        let primary_scheme = core::deep_link_handler::DeepLinkCallbackWaiter::get_protocol_scheme();
+
+        // 主协议（当前登录流程使用）
+        if let Err(err) = app.deep_link().register(primary_scheme) {
+            log::warn!("Failed to register deep link scheme `{primary_scheme}`: {err}");
+        }
+
+        // 兼容协议（历史版本）
+        if primary_scheme != "kiro-account-manager" {
+            if let Err(err) = app.deep_link().register("kiro-account-manager") {
+                log::warn!("Failed to register deep link scheme `kiro-account-manager`: {err}");
+            }
+        }
     }
 
     // 监听 deep link URL
@@ -366,6 +434,9 @@ fn main() {
             // 应用设置命令
             get_app_settings,
             save_app_settings,
+            get_kiro_protocol_command,
+            set_kiro_protocol_executable,
+            reset_kiro_protocol_to_current_exe,
             // 使用量历史记录命令
             get_usage_history,
             save_usage_history_entry,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,7 +46,7 @@
   "plugins": {
     "deep-link": {
       "desktop": {
-        "schemes": ["kiro-account-manager"]
+        "schemes": ["kiro", "kiro-account-manager"]
       }
     },
     "updater": {

--- a/src/components/features/Settings/SettingsGeneral.tsx
+++ b/src/components/features/Settings/SettingsGeneral.tsx
@@ -1,4 +1,4 @@
-import { Clock, Globe, Search, Shield, Shuffle, AlertTriangle, Eye, EyeOff, Repeat, RefreshCw, Check, Copy } from 'lucide-react'
+import { Clock, Globe, Search, Shield, Shuffle, AlertTriangle, Eye, EyeOff, Repeat, RefreshCw, Check, Copy, Link2 } from 'lucide-react'
 import { Card, CardContent } from '../../ui/card'
 import { Input } from '../../ui/input'
 import { Switch } from '../../ui/switch'
@@ -33,6 +33,10 @@ interface SettingsGeneralProps {
   setBrowserPath: (path: string) => void;
   originalBrowserPath: string;
   savingBrowser: boolean;
+  kiroProtocolPath: string;
+  setKiroProtocolPath: (path: string) => void;
+  originalKiroProtocolPath: string;
+  savingKiroProtocol: boolean;
   detectedBrowsers: BrowserInfo[];
   showBrowserList: boolean;
   setShowBrowserList: (show: boolean) => void;
@@ -41,6 +45,8 @@ interface SettingsGeneralProps {
   handleResetSystemMachineGuid: () => void;
   handleDetectBrowsers: () => void;
   handleApplyBrowser: () => void;
+  handleApplyKiroProtocolPath: () => void;
+  handleResetKiroProtocolPath: () => void;
   handleAutoRefreshChange: (checked: boolean) => void;
   handleAutoRefreshIntervalChange: (value: string) => void;
   handleAutoChangeMachineIdChange: (checked: boolean) => void;
@@ -65,6 +71,10 @@ function SettingsGeneral({
   setBrowserPath, 
   originalBrowserPath, 
   savingBrowser, 
+  kiroProtocolPath,
+  setKiroProtocolPath,
+  originalKiroProtocolPath,
+  savingKiroProtocol,
   detectedBrowsers, 
   showBrowserList, 
   setShowBrowserList, 
@@ -73,6 +83,8 @@ function SettingsGeneral({
   handleResetSystemMachineGuid, 
   handleDetectBrowsers, 
   handleApplyBrowser, 
+  handleApplyKiroProtocolPath,
+  handleResetKiroProtocolPath,
   handleAutoRefreshChange, 
   handleAutoRefreshIntervalChange, 
   handleAutoChangeMachineIdChange, 
@@ -84,6 +96,7 @@ function SettingsGeneral({
 }: SettingsGeneralProps) {
   const accountToggleContainerClass = "bg-card hover:bg-muted/50 border border-border text-foreground"
   const browserChanged = browserPath !== originalBrowserPath
+  const kiroProtocolChanged = kiroProtocolPath !== originalKiroProtocolPath
 
   const [copiedField, setCopiedField] = React.useState<string | null>(null)
   const copiedTimerRef = React.useRef<NodeJS.Timeout | null>(null)
@@ -285,6 +298,52 @@ function SettingsGeneral({
           )}
 
           <p className="text-xs text-muted-foreground mt-3">{t('settings.browserTip')}</p>
+        </CardContent>
+      </Card>
+
+      {/* Kiro 协议映射 */}
+      <Card className="card-glow animate-slide-in-left delay-280 mb-6">
+        <CardContent className="p-6">
+          <div className="flex items-center gap-2 mb-1">
+            <Link2 size={18} className="text-primary" />
+            <h2 className="text-lg font-semibold text-foreground">Kiro 协议映射</h2>
+          </div>
+          <p className="text-sm text-muted-foreground mb-4">
+            管理 <code>kiro://</code> 与 <code>kiro-account-manager://</code> 的本机执行路径。安装路径变更后可在此修复。
+          </p>
+
+          <label className="block text-sm text-muted-foreground mb-2">协议执行文件路径</label>
+          <div className="flex gap-3">
+            <Input
+              value={kiroProtocolPath}
+              onChange={(e) => setKiroProtocolPath(e.target.value)}
+              placeholder="例如：C:\\Program Files\\Kiro Account Manager\\kiro-account-manager.exe"
+              className="text-foreground bg-background border-border flex-1"
+            />
+            <button
+              onClick={handleApplyKiroProtocolPath}
+              disabled={savingKiroProtocol || !kiroProtocolChanged}
+              className={`px-5 py-3 rounded-xl flex items-center gap-2 font-medium shadow-sm disabled:opacity-50 disabled:cursor-not-allowed border ${kiroProtocolChanged
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-muted text-muted-foreground border-border"
+                }`}
+            >
+              {savingKiroProtocol ? <RefreshCw size={16} className="animate-spin" /> : <Check size={16} />}
+              {savingKiroProtocol ? '保存中' : '应用'}
+            </button>
+            <button
+              onClick={handleResetKiroProtocolPath}
+              disabled={savingKiroProtocol}
+              className="px-4 py-3 border rounded-xl bg-card hover:bg-muted/50 border-border text-foreground flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <RefreshCw size={16} />
+              恢复当前程序
+            </button>
+          </div>
+
+          <p className="text-xs text-muted-foreground mt-3">
+            仅 Windows 需要此映射。若浏览器提示“打开 Electron”或找不到应用，通常是这里被旧软件占用。
+          </p>
         </CardContent>
       </Card>
 

--- a/src/components/features/Settings/index.tsx
+++ b/src/components/features/Settings/index.tsx
@@ -37,6 +37,9 @@ function Settings() {
     const [browserPath, setBrowserPath] = useState('')
     const [originalBrowserPath, setOriginalBrowserPath] = useState('')
     const [savingBrowser, setSavingBrowser] = useState(false)
+    const [kiroProtocolPath, setKiroProtocolPath] = useState('')
+    const [originalKiroProtocolPath, setOriginalKiroProtocolPath] = useState('')
+    const [savingKiroProtocol, setSavingKiroProtocol] = useState(false)
     const [detectedBrowsers, setDetectedBrowsers] = useState<any[]>([])
     const [showBrowserList, setShowBrowserList] = useState(false)
     const [detectingProxy, setDetectingProxy] = useState(false)
@@ -79,16 +82,30 @@ function Settings() {
     const [machineGuidAction, setMachineGuidAction] = useState<string | null>(null) // 'reset'
 
     // 加载设置（指纹延迟加载，不阻塞页面）
+    const extractExecutablePath = (command: string) => {
+        const trimmed = String(command || '').trim()
+        if (!trimmed) return ''
+        if (trimmed.startsWith('"')) {
+            const secondQuote = trimmed.indexOf('"', 1)
+            if (secondQuote > 1) return trimmed.slice(1, secondQuote)
+        }
+        return trimmed.split(/\s+/)[0] || ''
+    }
+
     const loadSettings = useCallback(async () => {
         setLoading(true)
         try {
             // 先加载核心设置（快速）
-            const [kiroSettings, appSettings, sysMachine] = await Promise.all([
+            const [kiroSettings, appSettings, sysMachine, protocolCommand] = await Promise.all([
                 invoke<any>('get_kiro_settings').catch(() => null),
                 invoke<any>('get_app_settings').catch(() => null),
-                invoke<any>('get_system_machine_guid').catch(() => null)
+                invoke<any>('get_system_machine_guid').catch(() => null),
+                invoke<string>('get_kiro_protocol_command').catch(() => '')
             ])
             setSystemMachineInfo(sysMachine)
+            const protocolExePath = extractExecutablePath(protocolCommand || '')
+            setKiroProtocolPath(protocolExePath)
+            setOriginalKiroProtocolPath(protocolExePath)
 
             // 从 Kiro IDE 设置读取
             if (kiroSettings) {
@@ -354,6 +371,42 @@ function Settings() {
         }
     }
 
+    const handleApplyKiroProtocolPath = async () => {
+        const normalized = kiroProtocolPath.trim()
+        if (!normalized) {
+            await showError('保存失败', '协议路径不能为空')
+            return
+        }
+
+        setSavingKiroProtocol(true)
+        try {
+            const command = await invoke<string>('set_kiro_protocol_executable', { path: normalized })
+            const exePath = extractExecutablePath(command || '')
+            setKiroProtocolPath(exePath || normalized)
+            setOriginalKiroProtocolPath(exePath || normalized)
+            await showSuccess('保存成功', 'Kiro 协议映射已更新')
+        } catch (err: any) {
+            await showError('保存失败', String(err))
+        } finally {
+            setSavingKiroProtocol(false)
+        }
+    }
+
+    const handleResetKiroProtocolPath = async () => {
+        setSavingKiroProtocol(true)
+        try {
+            const command = await invoke<string>('reset_kiro_protocol_to_current_exe')
+            const exePath = extractExecutablePath(command || '')
+            setKiroProtocolPath(exePath)
+            setOriginalKiroProtocolPath(exePath)
+            await showSuccess('已恢复', '协议映射已恢复为当前程序路径')
+        } catch (err: any) {
+            await showError('恢复失败', String(err))
+        } finally {
+            setSavingKiroProtocol(false)
+        }
+    }
+
     const handleDetectProxy = async () => {
         setDetectingProxy(true)
         try {
@@ -449,6 +502,10 @@ function Settings() {
                             setBrowserPath={setBrowserPath}
                             originalBrowserPath={originalBrowserPath}
                             savingBrowser={savingBrowser}
+                            kiroProtocolPath={kiroProtocolPath}
+                            setKiroProtocolPath={setKiroProtocolPath}
+                            originalKiroProtocolPath={originalKiroProtocolPath}
+                            savingKiroProtocol={savingKiroProtocol}
                             detectedBrowsers={detectedBrowsers}
                             showBrowserList={showBrowserList}
                             setShowBrowserList={setShowBrowserList}
@@ -457,6 +514,8 @@ function Settings() {
                             handleResetSystemMachineGuid={handleResetSystemMachineGuid}
                             handleDetectBrowsers={handleDetectBrowsers}
                             handleApplyBrowser={handleApplyBrowser}
+                            handleApplyKiroProtocolPath={handleApplyKiroProtocolPath}
+                            handleResetKiroProtocolPath={handleResetKiroProtocolPath}
                             handleAutoRefreshChange={handleAutoRefreshChange}
                             handleAutoRefreshIntervalChange={handleAutoRefreshIntervalChange}
                             handleAutoChangeMachineIdChange={handleAutoChangeMachineIdChange}

--- a/src/components/shared/AuthCallback.tsx
+++ b/src/components/shared/AuthCallback.tsx
@@ -7,6 +7,24 @@ export default function AuthCallback() {
   const [status, setStatus] = useState('loading')
   const [message, setMessage] = useState('')
 
+  const closeCurrentPage = async () => {
+    // 优先关闭 Tauri 窗口；若当前在外部浏览器，window.close 可能被浏览器拦截
+    try {
+      const { getCurrentWindow } = await import('@tauri-apps/api/window')
+      await getCurrentWindow().close()
+      return
+    } catch (_) {
+      // ignore, fallback below
+    }
+
+    window.close()
+    setTimeout(() => {
+      if (!document.hidden) {
+        setMessage('如果窗口未自动关闭，请手动关闭此页并返回应用。')
+      }
+    }, 500)
+  }
+
   useEffect(() => {
     setMessage(t('callback.processing'))
     
@@ -31,7 +49,7 @@ export default function AuthCallback() {
         setMessage(t('callback.success'))
 
         setTimeout(() => {
-          window.close()
+          closeCurrentPage()
         }, 3000)
 
       } catch (error) {
@@ -104,7 +122,7 @@ export default function AuthCallback() {
               {t('callback.autoCloseHint')}
             </p>
             <button
-              onClick={() => window.close()}
+              onClick={closeCurrentPage}
               className={`px-6 py-2 bg-primary text-primary-foreground rounded-lg transition-colors`}
             >
               {t('callback.closeWindow')}
@@ -115,7 +133,7 @@ export default function AuthCallback() {
         {status === 'error' && (
           <div className="text-center">
             <button
-              onClick={() => window.close()}
+              onClick={closeCurrentPage}
               className={`px-6 py-2 bg-secondary text-secondary-foreground rounded-lg transition-colors`}
             >
               {t('callback.closeWindow')}


### PR DESCRIPTION
GitHub授权登录，使用1.8.3的实现（我不知道1.8.4这块改了什么，但就是不能用），然后新增kiro://协议修改到当前KAM的路径，在安装了kiro IDE且在后台启动的情况下，浏览器GitHub授权登录之后必定拉起KAM，如果未安装kiro IDE也能正常拉起KAM登录，使用反代等功能