### PR TITLE
fix: register main window reveal command

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,7 +18,7 @@ use core::account::{AccountStore, GroupTagStore};
 use auth::AuthState;
 use state::AppState;
 use std::sync::Mutex;
-use tauri::Listener;
+use tauri::{Listener, Manager};
 use services::session_storage::SessionStorage;
 
 // 导入命令
@@ -224,6 +224,25 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[tauri::command]
+fn reveal_main_window(app: tauri::AppHandle) -> Result<(), String> {
+    let Some(window) = app.get_webview_window("main") else {
+        return Err("main window not found".to_string());
+    };
+
+    window
+        .unminimize()
+        .map_err(|e| format!("failed to unminimize main window: {e}"))?;
+    window
+        .show()
+        .map_err(|e| format!("failed to show main window: {e}"))?;
+    window
+        .set_focus()
+        .map_err(|e| format!("failed to focus main window: {e}"))?;
+
+    Ok(())
+}
+
 #[allow(clippy::too_many_lines)] // Tauri 框架要求在 main 中注册所有命令，无法拆分
 fn main() {
     tauri::Builder::default()
@@ -348,6 +367,8 @@ fn main() {
             restart_as_admin,
             // 浏览器检测
             detect_installed_browsers,
+            // 窗口控制
+            reveal_main_window,
             // MCP 管理命令
             get_mcp_config,
             save_mcp_server,


### PR DESCRIPTION
## English

### Summary
- Register the missing `reveal_main_window` Tauri command used by the frontend after first paint.
- The command restores, shows, and focuses the `main` webview window.

### Why
The frontend already invokes `reveal_main_window` during startup, but the backend did not expose this command in `generate_handler!`. On macOS this can leave the application process running without a visible main window.

### Verification
- `npm run build`
- `cargo check`

`cargo check` passes with existing unused-code warnings in unrelated files.

## 中文

### 变更摘要
- 注册前端首屏渲染后调用的 `reveal_main_window` Tauri 命令。
- 该命令会恢复、显示并聚焦 `main` WebView 窗口。

### 修复原因
前端启动阶段已经调用 `reveal_main_window`，但后端没有在 `generate_handler!` 中暴露这个命令。在 macOS 上这会导致应用进程已经启动，但主窗口没有显示出来。

### 验证
- `npm run build`
- `cargo check`

`cargo check` 已通过，仅保留项目中已有的无关 unused warning。