### PR TITLE
fix: 为 macOS 隐藏启动补充主窗口兜底显示

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -217,6 +217,15 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         handle_deep_link_event(&app_handle, event.payload());
     });
 
+    #[cfg(target_os = "macos")]
+    {
+        let app_handle = app.handle().clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+            let _ = show_main_window(app_handle);
+        });
+    }
+
     let app_handle = app.handle().clone();
     tauri::async_runtime::spawn(async move {
         if let Err(err) = gateway::auto_start_if_enabled(&app_handle).await {


### PR DESCRIPTION
## 背景

`v1.8.6` 已经通过前端 `show_main_window` 改善了主窗口显示逻辑，但在本地 macOS 环境里，仍然会出现一种情况：

- 应用进程已经成功启动
- 前端链路没有稳定把主窗口拉起来
- 用户侧表现为点击 App 后没有界面弹出

我本地复测过两种情况：

1. 保持当前上游方案（隐藏启动，只依赖前端触发显示）时，窗口显示不稳定
2. 在不改 `visible: false` 策略的前提下，只补一个 macOS 原生延迟兜底后，页面可以稳定展示出来

## 这次改动

只做一个最小补丁：

- 保持现有 `visible: false`
- 在 `setup_app` 中为 macOS 增加一次延迟 600ms 的 `show_main_window` 兜底调用

这样不会改变当前避免白屏的主思路，只是在前端触发没有稳定生效时，多一层原生兜底。

## 改动范围

- `src-tauri/src/main.rs`

## 本地验证

我本地按下面方式验证过：

- 仅保留这个 fallback
- 不修改 `tauri.conf.json` 的 `visible: false`
- 重新打包、安装、启动

结果：

- 不加这段 fallback 时，本地存在“启动后没有窗口”的情况
- 只加这段 fallback 时，页面可以正常展示出来
