### PR TITLE
fix: Enterprise 账号不应使用默认 profileArn，修复网关 403 错误

### DIFF
--- a/src-tauri/src/commands/account_cmd.rs
+++ b/src-tauri/src/commands/account_cmd.rs
@@ -1732,12 +1732,14 @@ pub async fn set_overage_status(
     let overage_status = if enabled { "ENABLED" } else { "DISABLED" };
     let client = KiroQClient::new()?;
 
+    let profile_arn_str = ctx.profile_arn.as_deref().unwrap_or("");
+
     let result = client
         .set_user_preference(
             &final_access_token,
             &ctx.machine_id,
             &ctx.region,
-            &ctx.profile_arn,
+            profile_arn_str,
             overage_status,
         )
         .await;
@@ -1763,7 +1765,7 @@ pub async fn set_overage_status(
                     &refresh_result.access_token,
                     &ctx.machine_id,
                     &ctx.region,
-                    &ctx.profile_arn,
+                    profile_arn_str,
                     overage_status,
                 )
                 .await?;

--- a/src-tauri/src/commands/common.rs
+++ b/src-tauri/src/commands/common.rs
@@ -60,12 +60,12 @@ pub fn find_account_by_id(
 ///
 /// 解析规则：
 /// - machine_id：账号自带（非空）→ 否则系统 machine_guid
-/// - profile_arn：账号自带 → 否则 provider 默认 ARN
+/// - profile_arn：账号自带 → Enterprise 返回 None → 否则 provider 默认 ARN
 /// - region：profile_arn 解析出来的 region 优先 → 账号 region → fallback
 pub struct KiroCallContext {
     pub machine_id: String,
     pub region: String,
-    pub profile_arn: String,
+    pub profile_arn: Option<String>,
 }
 
 pub fn resolve_kiro_call_context(account: &Account, fallback_region: &str) -> KiroCallContext {
@@ -82,10 +82,16 @@ pub fn resolve_kiro_call_context(account: &Account, fallback_region: &str) -> Ki
         .profile_arn
         .clone()
         .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| resolve_default_profile_arn(account.provider.as_deref()).to_string());
+        .or_else(|| {
+            if account.provider.as_deref() == Some("Enterprise") {
+                None
+            } else {
+                Some(resolve_default_profile_arn(account.provider.as_deref()).to_string())
+            }
+        });
 
     let region = resolve_kiro_upstream_region(
-        Some(&profile_arn),
+        profile_arn.as_deref(),
         account.region.as_deref(),
         fallback_region,
     );

--- a/src-tauri/src/gateway/proxy.rs
+++ b/src-tauri/src/gateway/proxy.rs
@@ -2221,7 +2221,7 @@ async fn resolve_managed_account_credentials(
                 );
                 return Ok(UpstreamCredentials {
                     access_token: access_token.clone(),
-                    profile_arn: Some(ctx.profile_arn),
+                    profile_arn: ctx.profile_arn,
                     provider: account.provider.clone(),
                     region: ctx.region,
                     source_label: format_managed_upstream_source(&state.config, &account),
@@ -2289,8 +2289,15 @@ async fn resolve_managed_account_credentials(
                 .clone()
                 .filter(|value| !value.trim().is_empty())
                 .unwrap_or_else(get_machine_id);
-            let profile_arn = refresh.profile_arn.or_else(|| account.profile_arn.clone())
-                .or_else(|| Some(resolve_default_profile_arn(account.provider.as_deref()).to_string()));
+            let profile_arn = refresh.profile_arn
+                .or_else(|| account.profile_arn.clone())
+                .or_else(|| {
+                    if account.provider.as_deref() == Some("Enterprise") {
+                        None
+                    } else {
+                        Some(resolve_default_profile_arn(account.provider.as_deref()).to_string())
+                    }
+                });
             let region = resolve_kiro_upstream_region(
                 profile_arn.as_deref(),
                 account.region.as_deref(),


### PR DESCRIPTION
## 问题
Enterprise（IdC）账号通过网关调用 Kiro API 时，所有 `/v1/messages` 请求均返回 403：
The bearer token included in the request is invalid.
## 根因
`resolve_kiro_call_context()` (common.rs) 在账号的 `profileArn` 为 `None` 时，会 fallback 到 `KIRO_BUILDER_ID_PROFILE_ARN`（硬编码的 `AAAACCCCXXXX`）。
但 **Enterprise 账号不需要 profileArn**，这在同文件的 `get_usage_by_account()` 中已正确处理（对 Enterprise 返回 `None`），两处逻辑不一致。
### 影响链路
resolve_kiro_call_context() → 返回 AAAACCCCXXXX
  → proxy.rs resolve_upstream_credentials() → 将假 ARN 发给 Kiro API
    → Kiro API 校验 token 与 ARN 不匹配 → 403
## 修复
| 文件 | 改动 |
|------|------|
| `src-tauri/src/commands/common.rs` | `KiroCallContext.profile_arn` 类型从 `String` 改为 `Option<String>`；`resolve_kiro_call_context()` 对 Enterprise provider 返回 `None` 而非 fallback 到默认 ARN |
| `src-tauri/src/gateway/proxy.rs` | 无 refresh 路径：`Some(ctx.profile_arn)` → `ctx.profile_arn`（已适配 Option）；refresh fallback 路径：同样对 Enterprise 跳过默认 ARN |
| `src-tauri/src/commands/account_cmd.rs` | `set_user_preference` 调用适配 `Option<String>`，使用 `as_deref().unwrap_or("")` |
### 为什么安全
- `KiroPayload` 已有 `#[serde(skip_serializing_if = "Option::is_none")]`，`profileArn` 为 `None` 时不会序列化到 JSON
- `UpstreamCredentials.profile_arn` 本身就是 `Option<String>`
- HTTP header `x-amzn-kiro-profile-arn` 在设置前已有 `if let Some(...)` 检查
- 对 BuilderId / Social 等 provider 的行为不变
## 测试
- `cargo check` 编译通过，无新增错误或警告
- 仅影响 Enterprise provider 的 profileArn 处理逻辑，其他 provider 行为不变