### PR TITLE
fix(gateway): restore original MCP tool names in streaming tool_use

### DIFF
--- a/src-tauri/src/gateway/converter.rs
+++ b/src-tauri/src/gateway/converter.rs
@@ -2518,7 +2518,8 @@ fn extract_tool_uses(message: &NormalizedMessage) -> Option<Vec<KiroToolUse>> {
     let tool_uses: Vec<KiroToolUse> = tool_calls
         .iter()
         .map(|tool_call| KiroToolUse {
-            name: tool_call.function.name.clone(),
+            // 与 toolSpecification 保持一致：历史里的 tool_use 名字也需 sanitize，否则 Kiro 拒绝（名字不匹配）
+            name: shorten_tool_name(&sanitize_tool_name(&tool_call.function.name)),
             input: serde_json::from_str(&tool_call.function.arguments)
                 .unwrap_or_else(|_| json!({})),
             tool_use_id: tool_call.id.clone(),

--- a/src-tauri/src/gateway/proxy.rs
+++ b/src-tauri/src/gateway/proxy.rs
@@ -3243,6 +3243,8 @@ fn stream_proxy_response(
                                             saw_tool_calls = true;
                                             // 还原工具名称
                                             let original_name = restore_tool_name(&name);
+                                            // 修复：用还原后的原始工具名发给客户端，否则 Claude Code 收到 sanitized 名会报 "No such tool available"
+                                            let name = original_name.clone();
                                             tool_accumulators
                                                 .entry(id.clone())
                                                 .or_insert((original_name.clone(), String::new()));


### PR DESCRIPTION
## 问题

流式 `ToolUseStart` 处理路径输出的是**经过 sanitize 的工具名**,而不是还原后的原始名。导致 Claude Code 等客户端收到 `mcpGithubGetMe` 这类名称(而非 `mcp__github__get_me`),并报错 `No such tool available`。

delta 兜底路径已经做了还原,但主路径没有,造成行为不一致。

## 改动

- `gateway/proxy.rs`:在流式 `ToolUseStart` 主路径还原 MCP 工具的原始名称,与 delta 兜底路径保持一致。
- `gateway/converter.rs`:对请求历史里的 `tool_use` 名称做 sanitize,使其与发往 Kiro 的 `toolSpecification` 一致,否则多轮工具调用会被拒绝。

改动很小:共 4 行新增、1 行删除,仅涉及 2 个文件。

## 测试

- 通过流式接口验证 `ToolUseStart` 返回的工具名为还原后的原始名(如 `mcp__github__get_me`),客户端不再报 `No such tool available`。
- 验证多轮工具调用场景下,请求历史中的 `tool_use` 名称与 `toolSpecification` 匹配,后续轮次不再被拒绝。