### PR TITLE
fix(gateway): prevent 400 errors on long conversations by sanitizing trimmed tool results

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,1 @@
-* text=auto
-
-*.rs text eol=lf
-*.js text eol=lf
-*.jsx text eol=lf
-*.json text eol=lf
-*.md text eol=lf
-*.toml text eol=lf
-*.css text eol=lf
-*.html text eol=lf
-*.yml text eol=lf
-*.yaml text eol=lf
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,12 @@
-* text=auto eol=lf
+* text=auto
+
+*.rs text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.toml text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/src-tauri/src/gateway/converter.rs
+++ b/src-tauri/src/gateway/converter.rs
@@ -826,11 +826,19 @@ pub async fn build_kiro_payload(
 
                 // 如果有 toolResults，必须保留前面的 assistant（带 toolUses）
                 if has_tool_results && idx > 0 {
-                    let prev = &conversation_messages[idx - 1];
-                    if prev.role == "assistant" {
-                        idx -= 1;
-                        kept_count += 1;
-                        keep_from_index = idx;
+                    let mut search_idx = idx;
+                    while search_idx > 0 {
+                        search_idx -= 1;
+                        let prev = &conversation_messages[search_idx];
+                        if prev.role == "assistant" {
+                            idx = search_idx;
+                            kept_count += 1;
+                            keep_from_index = idx;
+                            break;
+                        }
+                        if prev.role != "tool" {
+                            break;
+                        }
                     }
                 }
             } else if msg.role == "assistant" {
@@ -997,6 +1005,9 @@ pub async fn build_kiro_payload(
                     if content.trim().is_empty() && tool_results.is_empty() {
                         content = "Continue".to_string();
                     }
+                    if content.trim().is_empty() && !tool_results.is_empty() {
+                        content = "[Tool results]".to_string();
+                    }
                     
                     // 如果需要缓存系统提示，在用户上下文中添加缓存点
                     if should_add_cache_point {
@@ -1017,14 +1028,19 @@ pub async fn build_kiro_payload(
                     });
                 }
                 "tool" => {
+                    let mut content =
+                        if Some(index) == first_user_index && !system_prompt.is_empty() {
+                            system_prompt.clone()
+                        } else {
+                            String::new()
+                        };
+                    if content.trim().is_empty() {
+                        content = "[Tool results]".to_string();
+                    }
+
                     history_items.push(HistoryItem::User {
                         user_input_message: HistoryUserMessage {
-                            content: if Some(index) == first_user_index && !system_prompt.is_empty()
-                            {
-                                system_prompt.clone()
-                            } else {
-                                String::new()
-                            },
+                            content,
                             model_id: model_id.clone(),
                             origin: "AI_EDITOR".to_string(),
                             images: None,
@@ -1077,7 +1093,7 @@ pub async fn build_kiro_payload(
         });
 
         // sanitize 所有消息（包括 currentMessage）
-        let all_sanitized = sanitize_history(history_items);
+        let all_sanitized = sanitize_history(history_items, &model_id);
 
         // 分割：最后一条作为 currentMessage 的数据源，其余作为 history
         if all_sanitized.len() <= 1 {
@@ -1659,7 +1675,7 @@ fn extract_anthropic_tool_result_id(content: &Value) -> Option<String> {
 /// 3. 补充缺失的 toolResults
 /// 4. 修复交替（插入占位消息）
 /// 5. 确保以 user 结束
-fn sanitize_history(mut items: Vec<HistoryItem>) -> Vec<HistoryItem> {
+fn sanitize_history(mut items: Vec<HistoryItem>, fallback_model_id: &str) -> Vec<HistoryItem> {
     if items.is_empty() {
         return items;
     }
@@ -1669,7 +1685,7 @@ fn sanitize_history(mut items: Vec<HistoryItem>) -> Vec<HistoryItem> {
         items.insert(0, HistoryItem::User {
             user_input_message: HistoryUserMessage {
                 content: "Hello".to_string(),
-                model_id: String::new(),
+                model_id: fallback_model_id.to_string(),
                 origin: "AI_EDITOR".to_string(),
                 images: None,
                 user_input_message_context: None,
@@ -1705,43 +1721,83 @@ fn sanitize_history(mut items: Vec<HistoryItem>) -> Vec<HistoryItem> {
     }).map(|(_, item)| item).collect();
 
     // 步骤 3：补充缺失的 toolResults
-    // 如果 assistant 有 toolUses 但下一条 user 没有对应 toolResults，插入错误占位
+    // 如果 assistant 有 toolUses 但下一条 user 没有对应 toolResults，补充错误占位
     let mut patched: Vec<HistoryItem> = Vec::new();
-    for (idx, item) in items.iter().enumerate() {
-        patched.push(item.clone());
+    let mut idx = 0;
+    while idx < items.len() {
+        let item = items[idx].clone();
 
-        if let HistoryItem::Assistant { assistant_response_message } = item {
+        if let HistoryItem::Assistant { assistant_response_message } = &item {
             if let Some(tool_uses) = &assistant_response_message.tool_uses {
                 if !tool_uses.is_empty() {
                     // 检查下一条是否是带 toolResults 的 user
                     let next = items.get(idx + 1);
-                    let next_has_results = match next {
+                    let existing_result_ids: std::collections::HashSet<String> = match next {
                         Some(HistoryItem::User { user_input_message }) => {
                             user_input_message.user_input_message_context
                                 .as_ref()
                                 .and_then(|ctx| ctx.tool_results.as_ref())
-                                .map(|r| !r.is_empty())
-                                .unwrap_or(false)
+                                .map(|results| {
+                                    results.iter().map(|result| result.tool_use_id.clone()).collect()
+                                })
+                                .unwrap_or_default()
                         }
-                        _ => false,
+                        _ => std::collections::HashSet::new(),
                     };
 
-                    if !next_has_results {
-                        // 插入错误占位的 toolResults
-                        let error_results: Vec<KiroToolResult> = tool_uses.iter().map(|tu| {
-                            KiroToolResult {
-                                tool_use_id: tu.tool_use_id.clone(),
-                                content: vec![KiroToolResultContent::Text {
-                                    text: "Tool execution failed".to_string(),
-                                }],
-                                status: "error".to_string(),
+                    let missing_results: Vec<KiroToolResult> = tool_uses
+                        .iter()
+                        .filter(|tool_use| !existing_result_ids.contains(&tool_use.tool_use_id))
+                        .map(|tool_use| KiroToolResult {
+                            tool_use_id: tool_use.tool_use_id.clone(),
+                            content: vec![KiroToolResultContent::Text {
+                                text: "Tool execution failed".to_string(),
+                            }],
+                            status: "error".to_string(),
+                        })
+                        .collect();
+
+                    if !missing_results.is_empty() {
+                        patched.push(item);
+
+                        if let Some(HistoryItem::User { .. }) = next {
+                            let mut next_item = items[idx + 1].clone();
+                            if let HistoryItem::User {
+                                user_input_message,
+                            } = &mut next_item
+                            {
+                                if user_input_message.content.trim().is_empty() {
+                                    user_input_message.content =
+                                        "[Tool results]".to_string();
+                                }
+                                let ctx = user_input_message
+                                    .user_input_message_context
+                                    .get_or_insert_with(|| UserInputMessageContext {
+                                        additional_context: None,
+                                        app_studio_context: None,
+                                        console_state: None,
+                                        diagnostic: None,
+                                        editor_state: None,
+                                        env_state: None,
+                                        git_state: None,
+                                        shell_state: None,
+                                        tool_results: None,
+                                        tools: None,
+                                        user_settings: None,
+                                    });
+                                ctx.tool_results
+                                    .get_or_insert_with(Vec::new)
+                                    .extend(missing_results);
                             }
-                        }).collect();
+                            patched.push(next_item);
+                            idx += 2;
+                            continue;
+                        }
 
                         patched.push(HistoryItem::User {
                             user_input_message: HistoryUserMessage {
-                                content: String::new(),
-                                model_id: String::new(),
+                                content: "[Tool execution failed]".to_string(),
+                                model_id: fallback_model_id.to_string(),
                                 origin: "AI_EDITOR".to_string(),
                                 images: None,
                                 user_input_message_context: Some(UserInputMessageContext {
@@ -1753,18 +1809,76 @@ fn sanitize_history(mut items: Vec<HistoryItem>) -> Vec<HistoryItem> {
                                     env_state: None,
                                     git_state: None,
                                     shell_state: None,
-                                    tool_results: Some(error_results),
+                                    tool_results: Some(missing_results),
                                     tools: None,
                                     user_settings: None,
                                 }),
                             },
                         });
+                        idx += 1;
+                        continue;
                     }
                 }
             }
         }
+
+        patched.push(item);
+        idx += 1;
     }
     items = patched;
+
+    // 步骤 3.5：user 有 toolResults 时，前一条必须是 assistant 且 ID 完全匹配
+    let mut cleaned_tool_results: Vec<HistoryItem> = Vec::new();
+    for item in items {
+        if let HistoryItem::User { user_input_message } = &item {
+            if let Some(results) = user_input_message
+                .user_input_message_context
+                .as_ref()
+                .and_then(|ctx| ctx.tool_results.as_ref())
+            {
+                if !results.is_empty() {
+                    let matching_assistant = match cleaned_tool_results.last() {
+                        Some(HistoryItem::Assistant {
+                            assistant_response_message,
+                        }) => {
+                            let tool_use_ids: std::collections::HashSet<String> =
+                                assistant_response_message
+                                    .tool_uses
+                                    .as_ref()
+                                    .map(|tool_uses| {
+                                        tool_uses
+                                            .iter()
+                                            .map(|tool_use| tool_use.tool_use_id.clone())
+                                            .collect()
+                                    })
+                                    .unwrap_or_default();
+                            results
+                                .iter()
+                                .all(|result| tool_use_ids.contains(&result.tool_use_id))
+                        }
+                        _ => false,
+                    };
+
+                    if !matching_assistant {
+                        let mut item = item;
+                        if let HistoryItem::User {
+                            user_input_message,
+                        } = &mut item
+                        {
+                            if user_input_message.content.trim().is_empty() {
+                                user_input_message.content = "Continue".to_string();
+                            }
+                            user_input_message.user_input_message_context = None;
+                        }
+                        cleaned_tool_results.push(item);
+                        continue;
+                    }
+                }
+            }
+        }
+        cleaned_tool_results.push(item);
+    }
+    items = cleaned_tool_results;
 
     // 步骤 4：修复交替（两个连续 user 之间插入 assistant，两个连续 assistant 之间插入 user）
     let mut alternated: Vec<HistoryItem> = Vec::new();
@@ -1792,7 +1906,7 @@ fn sanitize_history(mut items: Vec<HistoryItem>) -> Vec<HistoryItem> {
                 alternated.push(HistoryItem::User {
                     user_input_message: HistoryUserMessage {
                         content: "Continue".to_string(),
-                        model_id: String::new(),
+                        model_id: fallback_model_id.to_string(),
                         origin: "AI_EDITOR".to_string(),
                         images: None,
                         user_input_message_context: None,
@@ -2812,6 +2926,117 @@ mod tests {
         thread,
         time::Duration,
     };
+
+    fn history_user(
+        content: &str,
+        model_id: &str,
+        tool_results: Option<Vec<KiroToolResult>>,
+    ) -> HistoryItem {
+        HistoryItem::User {
+            user_input_message: HistoryUserMessage {
+                content: content.to_string(),
+                model_id: model_id.to_string(),
+                origin: "AI_EDITOR".to_string(),
+                images: None,
+                user_input_message_context: tool_results.map(|tool_results| {
+                    UserInputMessageContext {
+                        additional_context: None,
+                        app_studio_context: None,
+                        console_state: None,
+                        diagnostic: None,
+                        editor_state: None,
+                        env_state: None,
+                        git_state: None,
+                        shell_state: None,
+                        tool_results: Some(tool_results),
+                        tools: None,
+                        user_settings: None,
+                    }
+                }),
+            },
+        }
+    }
+
+    fn history_assistant_with_tools(tool_use_ids: &[&str]) -> HistoryItem {
+        HistoryItem::Assistant {
+            assistant_response_message: HistoryAssistantMessage {
+                content: "Using tools".to_string(),
+                tool_uses: Some(
+                    tool_use_ids
+                        .iter()
+                        .map(|tool_use_id| KiroToolUse {
+                            name: "search".to_string(),
+                            input: json!({}),
+                            tool_use_id: (*tool_use_id).to_string(),
+                        })
+                        .collect(),
+                ),
+                reasoning_content: None,
+                references: None,
+                supplementary_web_links: None,
+                followup_prompt: None,
+                message_id: None,
+                cache_point: None,
+            },
+        }
+    }
+
+    fn tool_result(tool_use_id: &str) -> KiroToolResult {
+        KiroToolResult {
+            content: vec![KiroToolResultContent::Text {
+                text: "ok".to_string(),
+            }],
+            status: "success".to_string(),
+            tool_use_id: tool_use_id.to_string(),
+        }
+    }
+
+    #[test]
+    fn sanitize_history_appends_only_missing_tool_results() {
+        let history = sanitize_history(
+            vec![
+                history_user("Hello", "claude-sonnet-4.5", None),
+                history_assistant_with_tools(&["call_1", "call_2"]),
+                history_user("[Tool results]", "claude-sonnet-4.5", Some(vec![tool_result("call_1")])),
+            ],
+            "claude-sonnet-4.5",
+        );
+
+        assert_eq!(history.len(), 3);
+        let HistoryItem::User { user_input_message } = &history[2] else {
+            panic!("expected user with tool results");
+        };
+        let results = user_input_message
+            .user_input_message_context
+            .as_ref()
+            .and_then(|ctx| ctx.tool_results.as_ref())
+            .expect("tool results should be present");
+        let ids: std::collections::HashSet<_> =
+            results.iter().map(|result| result.tool_use_id.as_str()).collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains("call_1"));
+        assert!(ids.contains("call_2"));
+    }
+
+    #[test]
+    fn sanitize_history_removes_orphaned_tool_results() {
+        let history = sanitize_history(
+            vec![
+                history_user("Hello", "claude-sonnet-4.5", None),
+                history_user("", "claude-sonnet-4.5", Some(vec![tool_result("orphaned")])),
+            ],
+            "claude-sonnet-4.5",
+        );
+
+        let HistoryItem::User { user_input_message } = history
+            .last()
+            .expect("sanitized history should retain final user")
+        else {
+            panic!("expected final user");
+        };
+        assert_eq!(user_input_message.content, "Continue");
+        assert!(user_input_message.user_input_message_context.is_none());
+    }
 
     /// 回归测试：工具描述超长且截断点落在多字节字符（中文）中间时不得 panic。
     /// 旧实现 `&desc[..TOOL_DESCRIPTION_MAX_LENGTH]` 按字节切，会在
@@ -3939,4 +4164,3 @@ mod tests {
         );
     }
 }
-

--- a/src-tauri/src/gateway/proxy.rs
+++ b/src-tauri/src/gateway/proxy.rs
@@ -667,10 +667,69 @@ async fn get_model_max_input_tokens(model_id: &str) -> usize {
     }
 }
 
+fn cleanup_orphaned_tool_results(history: &mut [Value]) {
+    let tool_use_ids: HashSet<String> = history
+        .iter()
+        .filter_map(|msg| msg.get("assistantResponseMessage"))
+        .filter_map(|msg| msg.get("toolUses"))
+        .filter_map(|tools| tools.as_array())
+        .flat_map(|tools| {
+            tools
+                .iter()
+                .filter_map(|tool| tool.get("toolUseId").and_then(Value::as_str))
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    for msg in history.iter_mut() {
+        let Some(user_msg) = msg
+            .get_mut("userInputMessage")
+            .and_then(Value::as_object_mut)
+        else {
+            continue;
+        };
+
+        let mut removed_all_results = false;
+        if let Some(ctx) = user_msg
+            .get_mut("userInputMessageContext")
+            .and_then(Value::as_object_mut)
+        {
+            if let Some(results) = ctx.get_mut("toolResults").and_then(Value::as_array_mut) {
+                let before = results.len();
+                results.retain(|result| {
+                    result
+                        .get("toolUseId")
+                        .and_then(Value::as_str)
+                        .map(|tool_use_id| tool_use_ids.contains(tool_use_id))
+                        .unwrap_or(true)
+                });
+                removed_all_results = before > 0 && results.is_empty();
+                if results.is_empty() {
+                    ctx.remove("toolResults");
+                }
+            }
+
+            if ctx.is_empty() {
+                user_msg.remove("userInputMessageContext");
+            }
+        }
+
+        let has_content = user_msg
+            .get("content")
+            .and_then(Value::as_str)
+            .map(|content| !content.trim().is_empty())
+            .unwrap_or(false);
+        if removed_all_results && !has_content {
+            user_msg.insert("content".to_string(), Value::String("Continue".to_string()));
+        }
+    }
+}
+
 /// 智能裁剪 Kiro payload 历史记录
 ///
 /// 策略：
-/// 1. 识别 tool call/result 配对（Assistant with tool_uses + User with tool_results）
+/// 1. 识别 tool call/result 配对（Assistant with toolUses + User with toolResults）
 /// 2. 从最旧的完整对话单元开始删除
 /// 3. 保留最近的对话（至少保留最后 2 条消息）
 /// 4. 避免破坏 tool_calls 和 tool_results 的配对关系
@@ -712,22 +771,22 @@ fn trim_kiro_payload_history(payload: &mut Value, max_bytes: usize) -> bool {
             break;
         }
 
-        // 检查第一条消息是否是 Assistant 消息且包含 tool_uses
+        // 检查第一条消息是否是 Assistant 消息且包含 toolUses
         let first_is_assistant_with_tools = history
             .first()
-            .and_then(|msg| msg.get("assistant_response_message"))
-            .and_then(|msg| msg.get("tool_uses"))
+            .and_then(|msg| msg.get("assistantResponseMessage"))
+            .and_then(|msg| msg.get("toolUses"))
             .and_then(|tools| tools.as_array())
             .map(|arr| !arr.is_empty())
             .unwrap_or(false);
 
         if first_is_assistant_with_tools && history.len() > 1 {
-            // 检查第二条消息是否是 User 消息且包含 tool_results
+            // 检查第二条消息是否是 User 消息且包含 toolResults
             let second_has_tool_results = history
                 .get(1)
-                .and_then(|msg| msg.get("user_input_message"))
-                .and_then(|msg| msg.get("user_input_message_context"))
-                .and_then(|ctx| ctx.get("tool_results"))
+                .and_then(|msg| msg.get("userInputMessage"))
+                .and_then(|msg| msg.get("userInputMessageContext"))
+                .and_then(|ctx| ctx.get("toolResults"))
                 .and_then(|results| results.as_array())
                 .map(|arr| !arr.is_empty())
                 .unwrap_or(false);
@@ -739,6 +798,7 @@ fn trim_kiro_payload_history(payload: &mut Value, max_bytes: usize) -> bool {
                     history.remove(0);
                     history.remove(0); // 删除第二条（现在变成第一条了）
                     removed_count += 2;
+                    cleanup_orphaned_tool_results(history);
                     log::debug!("[网关] 移除工具调用/结果对。剩余: {}", history.len());
                     continue;
                 } else {
@@ -751,6 +811,7 @@ fn trim_kiro_payload_history(payload: &mut Value, max_bytes: usize) -> bool {
         // 单个消息可以安全删除
         history.remove(0);
         removed_count += 1;
+        cleanup_orphaned_tool_results(history);
         log::debug!("[网关] 移除单条消息。剩余: {}", history.len());
     }
 
@@ -4650,33 +4711,69 @@ mod tests {
         assert!(size > 0);
     }
 
+    fn assert_no_orphaned_tool_results(history: &[Value]) {
+        let tool_use_ids: HashSet<String> = history
+            .iter()
+            .filter_map(|msg| msg.get("assistantResponseMessage"))
+            .filter_map(|msg| msg.get("toolUses"))
+            .filter_map(|tools| tools.as_array())
+            .flat_map(|tools| {
+                tools
+                    .iter()
+                    .filter_map(|tool| tool.get("toolUseId").and_then(Value::as_str))
+                    .map(str::to_string)
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        for msg in history {
+            let Some(results) = msg
+                .get("userInputMessage")
+                .and_then(|msg| msg.get("userInputMessageContext"))
+                .and_then(|ctx| ctx.get("toolResults"))
+                .and_then(|results| results.as_array())
+            else {
+                continue;
+            };
+
+            for result in results {
+                let tool_use_id = result
+                    .get("toolUseId")
+                    .and_then(Value::as_str)
+                    .expect("toolResult must include toolUseId");
+                assert!(
+                    tool_use_ids.contains(tool_use_id),
+                    "orphaned toolResult left after trim: {tool_use_id}"
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_trim_kiro_payload_history_removes_oldest_messages() {
         let mut payload = json!({
             "conversationState": {
                 "history": [
                     {
-                        "user_input_message": {
-                            "user_input_message_context": {
-                                "text": "First message"
-                            }
+                        "userInputMessage": {
+                            "content": "First message",
+                            "userInputMessageContext": {}
                         }
                     },
                     {
-                        "assistant_response_message": {
-                            "text": "First response"
+                        "assistantResponseMessage": {
+                            "content": "First response"
                         }
                     },
                     {
-                        "user_input_message": {
-                            "user_input_message_context": {
-                                "text": "Second message"
-                            }
+                        "userInputMessage": {
+                            "content": "Second message",
+                            "userInputMessageContext": {}
                         }
                     },
                     {
-                        "assistant_response_message": {
-                            "text": "Second response"
+                        "assistantResponseMessage": {
+                            "content": "Second response"
                         }
                     }
                 ]
@@ -4701,11 +4798,11 @@ mod tests {
             "conversationState": {
                 "history": [
                     {
-                        "assistant_response_message": {
-                            "text": "Let me search for that",
-                            "tool_uses": [
+                        "assistantResponseMessage": {
+                            "content": "Let me search for that",
+                            "toolUses": [
                                 {
-                                    "id": "call_1",
+                                    "toolUseId": "call_1",
                                     "name": "search",
                                     "input": {"q": "test"}
                                 }
@@ -4713,41 +4810,132 @@ mod tests {
                         }
                     },
                     {
-                        "user_input_message": {
-                            "user_input_message_context": {
-                                "tool_results": [
+                        "userInputMessage": {
+                            "content": "",
+                            "userInputMessageContext": {
+                                "toolResults": [
                                     {
-                                        "call_id": "call_1",
-                                        "output": "Found results"
+                                        "toolUseId": "call_1",
+                                        "content": [{"text": "Found results"}],
+                                        "status": "success"
                                     }
                                 ]
                             }
                         }
                     },
                     {
-                        "user_input_message": {
-                            "user_input_message_context": {
-                                "text": "Recent message"
-                            }
+                        "assistantResponseMessage": {
+                            "content": "Recent response"
+                        }
+                    },
+                    {
+                        "userInputMessage": {
+                            "content": "Recent message",
+                            "userInputMessageContext": {}
                         }
                     }
                 ]
             }
         });
 
-        let max_bytes = 200;
+        // Reproduce the old bug: with snake_case key checks, trim removed only the
+        // assistant toolUse message and then stopped, leaving an orphan toolResult.
+        let mut assistant_only_trimmed = payload.clone();
+        assistant_only_trimmed
+            .pointer_mut("/conversationState/history")
+            .and_then(Value::as_array_mut)
+            .unwrap()
+            .remove(0);
+        let max_bytes = check_payload_size(&assistant_only_trimmed);
+
         let trimmed = trim_kiro_payload_history(&mut payload, max_bytes);
 
-        if trimmed {
-            let history = payload
-                .pointer("/conversationState/history")
-                .and_then(|v| v.as_array())
-                .unwrap();
+        assert!(trimmed);
+        let history = payload
+            .pointer("/conversationState/history")
+            .and_then(Value::as_array)
+            .unwrap();
 
-            if history.len() == 1 {
-                assert!(history[0].get("user_input_message").is_some());
+        assert_eq!(history.len(), 2);
+        assert!(history[0].get("assistantResponseMessage").is_some());
+        assert!(history[1].get("userInputMessage").is_some());
+        assert_no_orphaned_tool_results(history);
+    }
+
+    #[test]
+    fn test_trim_kiro_payload_history_cleans_non_adjacent_orphaned_tool_results() {
+        let mut payload = json!({
+            "conversationState": {
+                "history": [
+                    {
+                        "assistantResponseMessage": {
+                            "content": "Let me search for that",
+                            "toolUses": [
+                                {
+                                    "toolUseId": "call_1",
+                                    "name": "search",
+                                    "input": {"q": "test"}
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "userInputMessage": {
+                            "content": "Intermediate user message",
+                            "userInputMessageContext": {}
+                        }
+                    },
+                    {
+                        "userInputMessage": {
+                            "content": "",
+                            "userInputMessageContext": {
+                                "toolResults": [
+                                    {
+                                        "toolUseId": "call_1",
+                                        "content": [{"text": "Found results"}],
+                                        "status": "success"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "assistantResponseMessage": {
+                            "content": "Recent response"
+                        }
+                    },
+                    {
+                        "userInputMessage": {
+                            "content": "Recent message",
+                            "userInputMessageContext": {}
+                        }
+                    }
+                ]
             }
-        }
+        });
+
+        let mut assistant_only_trimmed = payload.clone();
+        assistant_only_trimmed
+            .pointer_mut("/conversationState/history")
+            .and_then(Value::as_array_mut)
+            .unwrap()
+            .remove(0);
+        let max_bytes = check_payload_size(&assistant_only_trimmed);
+
+        let trimmed = trim_kiro_payload_history(&mut payload, max_bytes);
+
+        assert!(trimmed);
+        let history = payload
+            .pointer("/conversationState/history")
+            .and_then(Value::as_array)
+            .unwrap();
+        assert_no_orphaned_tool_results(history);
+        assert_eq!(
+            history[1]
+                .pointer("/userInputMessage/content")
+                .and_then(Value::as_str),
+            Some("Continue")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

When a conversation exceeds the 30-message limit, Kiro history trimming exposes structural issues that cause the API to reject the payload with `400 Improperly formed request`. This blocks all further conversation until the session is reset.

## Root Causes

1. **Snake_case field names** in `trim_kiro_payload_history` did not match the actual camelCase serde serialization (`assistantResponseMessage`, `toolUses`, `toolUseId`), so tool call/result pairs were never detected and removed together — the assistant was trimmed alone, leaving orphaned toolResults.
2. **Empty `content`** on user messages that carry toolResults — Kiro rejects `content: ""` even when toolResults are present.
3. **Empty `modelId`** on placeholder messages inserted by `sanitize_history` — Kiro rejects `model_id: ""`.
4. **Orphaned toolResults** after trimming — when an assistant with toolUses is removed, subsequent user messages may still reference those deleted IDs.
5. **Partial toolResult groups** — when an assistant has multiple toolUses but the next user only has results for some of them, the old code inserted error placeholders for ALL toolUses, duplicating existing results.

## Fixes

### proxy.rs
- Fixed `trim_kiro_payload_history` to use correct camelCase field names.
- Added `cleanup_orphaned_tool_results()` — after every removal, strips any toolResult whose `toolUseId` no longer matches a remaining assistant `toolUse`. Also sets `"Continue"` as content when all results were stripped from an empty user message.

### converter.rs
- Non-empty `content` for tool-result user messages (`"[Tool results]"` placeholder).
- Non-empty `modelId` on generated placeholders (passed via `fallback_model_id` parameter).
- Backward assistant lookup across consecutive tool messages during trimming.
- `sanitize_history` Step 3 now appends only **missing** toolResults to the next user instead of duplicating existing ones.
- Step 3.5 strips orphaned toolResults (no matching preceding assistant).
- Partial tool result handling: merges missing results into the existing next user rather than inserting a duplicate user message.

## Testing

- `cargo test history -- --nocapture` — 5 focused tests pass
- `cargo build --release` — clean
- Manual verification: long conversation (>30 messages) no longer returns 400

### New test coverage
- `sanitize_history_appends_only_missing_tool_results` — verifies partial results are merged, not duplicated
- `sanitize_history_removes_orphaned_tool_results` — verifies orphaned results are stripped and content is set to `"Continue"`
- `test_trim_kiro_payload_history_preserves_tool_call_pairs` — adjacent pair removal with orphan assertion
- `test_trim_kiro_payload_history_cleans_non_adjacent_orphaned_tool_results` — non-adjacent orphan cleanup after trimming

## Notes

- Left local generated files out of the PR: `package-lock.json` and `src-tauri/gen/schemas/linux-schema.json`.
- Broader `gateway::converter::tests` has pre-existing expectation failures unrelated to this fix (`searchDocs`/`search_docs` naming and historical placeholder expectations).