### PR TITLE
fix(accounts): use account-scoped machine IDs to prevent privacy leak

### DIFF
--- a/src-tauri/src/auth/providers/social.rs
+++ b/src-tauri/src/auth/providers/social.rs
@@ -3,7 +3,7 @@
 
 use super::{AuthProvider, AuthResult, RefreshMetadata};
 use crate::auth::auth_social;
-use crate::commands::machine_guid::get_machine_id;
+use crate::commands::machine_guid::generate_random_machine_id;
 use crate::core::deep_link_handler::{register_waiter, DeepLinkCallbackWaiter};
 use crate::clients::kiro_auth_client::KiroAuthServiceClient;
 use async_trait::async_trait;
@@ -68,7 +68,7 @@ impl AuthProvider for SocialProvider {
         let waiter = register_waiter(&state);
 
         // Step 4: 打开浏览器登录
-        let machine_id = get_machine_id();
+        let machine_id = generate_random_machine_id();
         let client = KiroAuthServiceClient::new(&machine_id)?;
         client
             .login(provider, &redirect_uri, &code_challenge, &state)
@@ -113,8 +113,8 @@ impl AuthProvider for SocialProvider {
         refresh_token: &str,
         metadata: RefreshMetadata,
     ) -> Result<AuthResult, String> {
-        // 优先使用账号的 machineId，没有则用系统机器码
-        let machine_id = metadata.machine_id.unwrap_or_else(get_machine_id);
+        // 优先使用账号的 machineId，没有则生成账号独立 ID
+        let machine_id = metadata.machine_id.unwrap_or_else(generate_random_machine_id);
         let client = KiroAuthServiceClient::new(&machine_id)?;
         let token_response: SocialRefreshResponse = client.refresh_token(refresh_token).await?;
 

--- a/src-tauri/src/commands/account_cmd.rs
+++ b/src-tauri/src/commands/account_cmd.rs
@@ -10,10 +10,12 @@ use crate::commands::account_models::{
     write_available_models_cache, ListAvailableModelsResponse,
 };
 use crate::commands::common::{
-    calc_expires_at, extract_user_info, find_account_by_id,
-    find_existing_account_idx, get_enterprise_usage_with_region_probe, get_usage_by_account,
-    get_usage_by_provider, is_auth_error_message, is_token_expired, is_token_expiring_soon,
-    lock_store, refresh_token_by_provider, save_store, token_needs_refresh, update_account_status, RefreshResult,
+    calc_expires_at, ensure_account_machine_id, extract_user_info, find_account_by_id,
+    find_existing_account_idx, generate_account_machine_id, get_enterprise_usage_with_region_probe,
+    account_machine_id_or_new, get_usage_by_account, get_usage_by_provider,
+    get_usage_by_provider_with_machine_id, is_auth_error_message, is_token_expired,
+    is_token_expiring_soon, lock_store, refresh_token_by_provider, save_store,
+    token_needs_refresh, update_account_status, RefreshResult,
 };
 use crate::auth::providers::{AuthProvider, IdcProvider, RefreshMetadata};
 use crate::state::AppState;
@@ -137,10 +139,8 @@ pub async fn sync_account(
 
     // 如果账号缺少 machine_id，自动生成一个（所有账号都需要）
     let mut account = account.clone();
-    if account.machine_id.is_none() {
-        use crate::commands::machine_guid::get_machine_id;
-        let machine_id = get_machine_id();
-        account.machine_id = Some(machine_id);
+    if account.machine_id.as_ref().is_none_or(|id| id.trim().is_empty()) {
+        ensure_account_machine_id(&mut account);
         log::info!("Generated machine_id for account: {}", account.id);
     }
 
@@ -154,7 +154,7 @@ pub async fn sync_account(
             .await
             .map(|(result, _region)| result)
     } else {
-        get_usage_by_provider(provider_str, access_token).await
+        get_usage_by_account(&account, access_token).await
     };
 
     let mut refresh_result: Option<RefreshResult> = None;
@@ -182,7 +182,7 @@ pub async fn sync_account(
                         Err(e) => Err(e),
                     }
                 } else {
-                    get_usage_by_provider(provider_str, &refreshed.access_token).await
+                    get_usage_by_account(&account, &refreshed.access_token).await
                 };
                 refresh_result = Some(refreshed);
             }
@@ -216,8 +216,9 @@ pub async fn sync_account(
     let mut store = lock_store(&state.store, "store")?;
     let result = if let Some(a) = store.accounts.iter_mut().find(|a| a.id == id) {
         // 如果生成了新的 machine_id，保存它（所有账号都需要）
-        // 如果生成了新的 machine_id，保存它（所有账号都需要）
-        if account.machine_id.is_some() && a.machine_id.is_none() {
+        if account.machine_id.is_some()
+            && a.machine_id.as_ref().is_none_or(|id| id.trim().is_empty())
+        {
             a.machine_id = account.machine_id.clone();
             log::info!("Saved machine_id for account: {}", a.id);
         }
@@ -296,7 +297,25 @@ pub async fn refresh_account_token(
     state: State<'_, AppState>,
     id: String,
 ) -> Result<Account, String> {
-    let account = find_account_by_id(&state, &id)?;
+    let mut account = find_account_by_id(&state, &id)?;
+    let account_machine_id = if account
+        .machine_id
+        .as_ref()
+        .is_none_or(|id| id.trim().is_empty())
+    {
+        Some(ensure_account_machine_id(&mut account))
+    } else {
+        None
+    };
+    if let Some(ref machine_id) = account_machine_id {
+        let mut store = lock_store(&state.store, "store")?;
+        if let Some(a) = store.accounts.iter_mut().find(|a| a.id == id) {
+            if a.machine_id.as_ref().is_none_or(|id| id.trim().is_empty()) {
+                a.machine_id = Some(machine_id.clone());
+                save_store(&store)?;
+            }
+        }
+    }
 
     // 检查 token 是否还有 5 分钟以上有效期
     if let Some(expires_at) = &account.expires_at {
@@ -331,6 +350,9 @@ pub async fn refresh_account_token(
     let mut store = lock_store(&state.store, "store")?;
     if let Some(a) = store.accounts.iter_mut().find(|a| a.id == id) {
         clear_available_models_cache(a);
+        if a.machine_id.as_ref().is_none_or(|id| id.trim().is_empty()) {
+            a.machine_id = account_machine_id;
+        }
         // 直接移动所有权，避免 clone
         a.access_token = Some(refresh_result.access_token);
         a.refresh_token = refresh_result.refresh_token;
@@ -411,6 +433,7 @@ pub async fn verify_account(
 
         let mut temp_account = account.clone();
         temp_account.access_token = Some(new_access_token.clone());
+        ensure_account_machine_id(&mut temp_account);
         temp_account
     }; // MutexGuard 在这里被释放
 
@@ -428,6 +451,9 @@ pub async fn verify_account(
             // 更新 token
             account.access_token = Some(new_access_token.clone()); // ✅ 这里必须 clone，因为后面还要用
             account.refresh_token = Some(new_refresh_token.clone()); // ✅ 这里必须 clone，因为后面还要用
+            if account.machine_id.as_ref().is_none_or(|id| id.trim().is_empty()) {
+                account.machine_id = temp_account.machine_id.clone();
+            }
             // 更新 usage_data 和状态（检测封禁）
             account.usage_data = Some(usage_result.usage_data);
             update_account_status(account, usage_result.is_banned, usage_result.is_auth_error);
@@ -451,16 +477,24 @@ pub async fn add_account_by_social(
     access_token: Option<String>,
 ) -> Result<AddAccountResult, String> {
     let idp = provider.as_deref().unwrap_or("Google").to_string(); // ✅ 避免不必要的 clone
+    let account_machine_id = machine_id
+        .filter(|id| !id.trim().is_empty())
+        .unwrap_or_else(generate_account_machine_id);
 
     // 先尝试用传入的 access_token 获取配额
     let (final_access_token, final_refresh_token, final_profile_arn, usage_result) =
         if let Some(at) = access_token {
-            match get_usage_by_provider(&idp, &at).await {
+            match get_usage_by_provider_with_machine_id(&idp, &at, &account_machine_id).await {
                 Ok(result) if result.is_auth_error => {
                     // 401 了，刷新 token
                     let refresh_result = refresh_token_desktop(&refresh_token).await?;
                     let new_usage =
-                        get_usage_by_provider(&idp, &refresh_result.access_token).await?;
+                        get_usage_by_provider_with_machine_id(
+                            &idp,
+                            &refresh_result.access_token,
+                            &account_machine_id,
+                        )
+                        .await?;
                     (
                         refresh_result.access_token,
                         refresh_result.refresh_token,
@@ -483,7 +517,12 @@ pub async fn add_account_by_social(
         } else {
             // 没有 access_token，直接刷新
             let refresh_result = refresh_token_desktop(&refresh_token).await?;
-            let usage_result = get_usage_by_provider(&idp, &refresh_result.access_token).await?;
+            let usage_result = get_usage_by_provider_with_machine_id(
+                &idp,
+                &refresh_result.access_token,
+                &account_machine_id,
+            )
+            .await?;
             (
                 refresh_result.access_token,
                 refresh_result.refresh_token,
@@ -534,6 +573,9 @@ pub async fn add_account_by_social(
         existing.profile_arn = Some(final_profile_arn.clone()); // ✅ 保存 profile_arn
         existing.user_id = user_id;
         existing.usage_data = Some(usage_result.usage_data);
+        if existing.machine_id.as_ref().is_none_or(|id| id.trim().is_empty()) {
+            existing.machine_id = Some(account_machine_id.clone());
+        }
         update_account_status(existing, usage_result.is_banned, usage_result.is_auth_error);
         existing.clone() // ✅ 必须 clone，因为要返回给前端
     } else {
@@ -547,8 +589,7 @@ pub async fn add_account_by_social(
         account.usage_data = Some(usage_result.usage_data);
         update_account_status(&mut account, usage_result.is_banned, usage_result.is_auth_error);
         // 使用传入的 machine_id，没有则自动生成
-        account.machine_id =
-            machine_id.or_else(|| Some(uuid::Uuid::new_v4().to_string().to_lowercase())); // ✅ 避免 clone
+        account.machine_id = Some(account_machine_id);
         store.accounts.insert(0, account.clone());
         account
     };
@@ -801,7 +842,8 @@ async fn add_account_by_idc_internal(
     let machine_id = params
         .machine_id
         .clone()
-        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string().to_lowercase());
+        .filter(|id| !id.trim().is_empty())
+        .unwrap_or_else(generate_account_machine_id);
 
     // 企业账号导入时强制刷新 token（导入时的 access_token 很可能已过期）
     let (
@@ -830,7 +872,12 @@ async fn add_account_by_idc_internal(
             region = detected_region;
             result
         } else {
-            get_usage_by_provider(&params.provider_id, &auth_result.access_token).await?
+            get_usage_by_provider_with_machine_id(
+                &params.provider_id,
+                &auth_result.access_token,
+                &machine_id,
+            )
+            .await?
         };
 
         let expires_at = calc_expires_at(auth_result.expires_in);
@@ -844,46 +891,50 @@ async fn add_account_by_idc_internal(
         )
     } else if let Some(at) = params.access_token {
         // BuilderId 且有 access_token 时，先尝试使用
-            // BuilderId 使用原有逻辑
-            match get_usage_by_provider(&params.provider_id, &at).await {
-                Ok(result) if result.is_auth_error => {
-                    // 401 了，刷新 token
-                    let metadata = RefreshMetadata {
-                        client_id: Some(params.client_id.clone()),
-                        client_secret: Some(params.client_secret.clone()),
-                        region: Some(region.clone()),
-                        ..Default::default()
-                    };
-                    let idc_provider =
-                        IdcProvider::new(&params.provider_id, &region, start_url.clone());
-                    let auth_result = idc_provider
-                        .refresh_token(&params.refresh_token, metadata)
-                        .await?;
-                    let new_usage =
-                        get_usage_by_provider(&params.provider_id, &auth_result.access_token).await?;
-                    let expires_at = calc_expires_at(auth_result.expires_in);
-                    (
-                        auth_result.access_token,
-                        auth_result.refresh_token,
-                        new_usage,
-                        expires_at,
-                        auth_result.id_token,
-                        auth_result.sso_session_id,
-                    )
-                }
-                Ok(result) => {
-                    // access_token 有效，不需要刷新
-                    (
-                        at,
-                        params.refresh_token.clone(),
-                        result,
-                        String::new(),
-                        None,
-                        None,
-                    )
-                }
-                Err(e) => return Err(e),
+        // BuilderId 使用原有逻辑
+        match get_usage_by_provider_with_machine_id(&params.provider_id, &at, &machine_id).await {
+            Ok(result) if result.is_auth_error => {
+                // 401 了，刷新 token
+                let metadata = RefreshMetadata {
+                    client_id: Some(params.client_id.clone()),
+                    client_secret: Some(params.client_secret.clone()),
+                    region: Some(region.clone()),
+                    ..Default::default()
+                };
+                let idc_provider =
+                    IdcProvider::new(&params.provider_id, &region, start_url.clone());
+                let auth_result = idc_provider
+                    .refresh_token(&params.refresh_token, metadata)
+                    .await?;
+                let new_usage = get_usage_by_provider_with_machine_id(
+                    &params.provider_id,
+                    &auth_result.access_token,
+                    &machine_id,
+                )
+                .await?;
+                let expires_at = calc_expires_at(auth_result.expires_in);
+                (
+                    auth_result.access_token,
+                    auth_result.refresh_token,
+                    new_usage,
+                    expires_at,
+                    auth_result.id_token,
+                    auth_result.sso_session_id,
+                )
             }
+            Ok(result) => {
+                // access_token 有效，不需要刷新
+                (
+                    at,
+                    params.refresh_token.clone(),
+                    result,
+                    String::new(),
+                    None,
+                    None,
+                )
+            }
+            Err(e) => return Err(e),
+        }
     } else {
         // 没有 access_token，直接刷新
         let metadata = RefreshMetadata {
@@ -903,7 +954,12 @@ async fn add_account_by_idc_internal(
             region = detected_region;
             result
         } else {
-            get_usage_by_provider(&params.provider_id, &auth_result.access_token).await?
+            get_usage_by_provider_with_machine_id(
+                &params.provider_id,
+                &auth_result.access_token,
+                &machine_id,
+            )
+            .await?
         };
 
         let expires_at = calc_expires_at(auth_result.expires_in);
@@ -970,6 +1026,9 @@ async fn add_account_by_idc_internal(
             existing.region = Some(region.clone());
             existing.client_id_hash = client_id_hash.clone(); // 可能是 None
             existing.start_url = start_url.clone();
+            if existing.machine_id.as_ref().is_none_or(|id| id.trim().is_empty()) {
+                existing.machine_id = Some(machine_id.clone());
+            }
             if id_token.is_some() {
                 existing.id_token = id_token;
             }
@@ -998,12 +1057,7 @@ async fn add_account_by_idc_internal(
             account.sso_session_id = sso_session_id;
             account.usage_data = Some(usage_result.usage_data);
             update_account_status(&mut account, usage_result.is_banned, usage_result.is_auth_error);
-            account.machine_id = Some(
-                params
-                    .machine_id
-                    .clone()
-                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string().to_lowercase()),
-            );
+            account.machine_id = Some(machine_id.clone());
             account.password.clone_from(&params.password);
             store.accounts.insert(0, account.clone());
             account
@@ -1047,6 +1101,9 @@ async fn add_account_by_idc_internal(
             existing.client_secret = Some(params.client_secret.clone());
             existing.region = Some(region.clone());
             existing.client_id_hash = client_id_hash.clone(); // 可能是 None
+            if existing.machine_id.as_ref().is_none_or(|id| id.trim().is_empty()) {
+                existing.machine_id = Some(machine_id.clone());
+            }
             if id_token.is_some() {
                 existing.id_token = id_token;
             }
@@ -1082,11 +1139,7 @@ async fn add_account_by_idc_internal(
             account.sso_session_id = sso_session_id;
             account.usage_data = Some(usage_result.usage_data);
             update_account_status(&mut account, usage_result.is_banned, usage_result.is_auth_error);
-            account.machine_id = Some(
-                params
-                    .machine_id
-                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string().to_lowercase()),
-            );
+            account.machine_id = Some(machine_id);
             account.password = params.password;
             store.accounts.insert(0, account.clone());
             account
@@ -1153,7 +1206,6 @@ pub async fn delete_account_remote(
     delete_local: bool,
 ) -> Result<String, String> {
     use crate::auth::delete_account_desktop;
-    use crate::commands::machine_guid::get_machine_id;
 
     // 获取账号信息
     let account = find_account_by_id(&state, &id)?;
@@ -1173,7 +1225,7 @@ pub async fn delete_account_remote(
         .ok_or("账号缺少 access_token，请先刷新")?;
 
     // Google/Github 账号使用 Desktop API
-    let machine_id = get_machine_id();
+    let machine_id = account_machine_id_or_new(&account.machine_id);
     delete_account_desktop(access_token, &machine_id).await?;
 
     // 如果需要同时删除本地记录

--- a/src-tauri/src/commands/account_models.rs
+++ b/src-tauri/src/commands/account_models.rs
@@ -1,5 +1,5 @@
 use crate::core::account::{Account, AvailableModelsCacheEntry};
-use crate::commands::machine_guid::get_machine_id;
+use crate::commands::common::account_machine_id_or_new;
 use crate::clients::http_client::{
     build_http_client_with_user_agent, build_kiro_custom_user_agent,
     build_q_service_url, resolve_kiro_upstream_region,
@@ -165,11 +165,7 @@ async fn fetch_available_models_page(
     model_provider: Option<&str>,
     next_token: Option<&str>,
 ) -> Result<ListAvailableModelsResponse, String> {
-    let machine_id = account
-        .machine_id
-        .clone()
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(get_machine_id);
+    let machine_id = account_machine_id_or_new(&account.machine_id);
     let user_agent = build_kiro_models_user_agent(&machine_id);
     let region = resolve_kiro_upstream_region(
         account.profile_arn.as_deref(),
@@ -824,4 +820,3 @@ mod tests {
         );
     }
 }
-

--- a/src-tauri/src/commands/auth_cmd.rs
+++ b/src-tauri/src/commands/auth_cmd.rs
@@ -7,10 +7,9 @@ use crate::core::protocol_registry;
 use crate::auth::User;
 use crate::auth::auth_social;
 use crate::commands::common::{
-    extract_user_info, find_existing_account_idx, get_usage_by_provider, lock_store,
-    save_store, update_account_status,
+    extract_user_info, find_existing_account_idx, generate_account_machine_id,
+    get_usage_by_provider_with_machine_id, lock_store, save_store, update_account_status,
 };
-use crate::commands::machine_guid::get_machine_id;
 use crate::clients::kiro_auth_client::KiroAuthServiceClient;
 use crate::auth::providers::{
     cancel_pending_idc_login, create_idc_provider, get_provider_config, AuthMethod, AuthProvider,
@@ -131,7 +130,7 @@ async fn login_social(
     protocol_registry::ensure_protocol_registration()?;
 
     let provider_id = config.provider_id.clone();
-    let pending = prepare_pending_social_login(&provider_id, get_machine_id());
+    let pending = prepare_pending_social_login(&provider_id, generate_account_machine_id());
     let redirect_uri = social_callback_redirect_uri();
     let code_challenge = auth_social::generate_code_challenge_social(&pending.code_verifier);
     let client = KiroAuthServiceClient::new(&pending.machineid)?;
@@ -166,7 +165,12 @@ async fn login_social(
         .await?;
 
     // 5. 获取配额信息
-    let usage_result = get_usage_by_provider(&provider_id, &token_result.access_token).await?;
+    let usage_result = get_usage_by_provider_with_machine_id(
+        &provider_id,
+        &token_result.access_token,
+        &pending.machineid,
+    )
+    .await?;
 
     // 封禁账号直接报错
     if usage_result.is_banned {
@@ -196,6 +200,7 @@ async fn login_social(
         existing.profile_arn = token_result.profile_arn.clone();
         existing.user_id = user_id;
         existing.usage_data = Some(usage_result.usage_data);
+        existing.machine_id = Some(pending.machineid.clone());
         update_account_status(existing, usage_result.is_banned, usage_result.is_auth_error);
         existing.clone()
     } else {
@@ -208,7 +213,7 @@ async fn login_social(
         account.user_id = user_id;
         account.usage_data = Some(usage_result.usage_data);
         update_account_status(&mut account, usage_result.is_banned, usage_result.is_auth_error);
-        account.machine_id = Some(uuid::Uuid::new_v4().to_string().to_lowercase());
+        account.machine_id = Some(pending.machineid.clone());
         store.accounts.insert(0, account.clone());
         account
     };
@@ -251,7 +256,13 @@ async fn login_idc(
 
     let auth_result = idc_provider.login().await?;
 
-    let usage_result = get_usage_by_provider(&provider_id, &auth_result.access_token).await?;
+    let account_machine_id = generate_account_machine_id();
+    let usage_result = get_usage_by_provider_with_machine_id(
+        &provider_id,
+        &auth_result.access_token,
+        &account_machine_id,
+    )
+    .await?;
 
     // 封禁账号直接报错
     if usage_result.is_banned {
@@ -289,6 +300,9 @@ async fn login_idc(
         existing.id_token = auth_result.id_token;
         existing.profile_arn = auth_result.profile_arn;
         existing.usage_data = Some(usage_result.usage_data);
+        if existing.machine_id.as_ref().is_none_or(|id| id.trim().is_empty()) {
+            existing.machine_id = Some(account_machine_id.clone());
+        }
         update_account_status(existing, usage_result.is_banned, usage_result.is_auth_error);
         existing.clone()
     } else {
@@ -310,10 +324,9 @@ async fn login_idc(
         account.usage_data = Some(usage_result.usage_data);
         update_account_status(&mut account, usage_result.is_banned, usage_result.is_auth_error);
 
-        // 为所有新账号生成 machine_id
-        use crate::commands::machine_guid::get_machine_id;
-        account.machine_id = Some(get_machine_id());
-        log::info!("Generated machine_id for new {} account", provider_id);
+        // 为所有新账号生成唯一的 machine_id（每个账号独立 UUID，避免隐私泄露）
+        account.machine_id = Some(account_machine_id);
+        log::info!("Generated unique machine_id for new {} account", provider_id);
         
         store.accounts.insert(0, account.clone());
         account
@@ -385,8 +398,12 @@ pub async fn handle_kiro_social_callback(
     )
     .await?;
 
-    let usage_result =
-        get_usage_by_provider(&pending.provider, &token_response.access_token).await?;
+    let usage_result = get_usage_by_provider_with_machine_id(
+        &pending.provider,
+        &token_response.access_token,
+        &pending.machineid,
+    )
+    .await?;
 
     if usage_result.is_banned {
         return Err("BANNED: 账号已被封禁".to_string());
@@ -411,6 +428,7 @@ pub async fn handle_kiro_social_callback(
         existing.email.clone_from(&new_email);
         existing.user_id.clone_from(&user_id);
         existing.usage_data = Some(usage_result.usage_data);
+        existing.machine_id = Some(pending.machineid.clone());
         update_account_status(existing, usage_result.is_banned, usage_result.is_auth_error);
         existing.clone()
     } else {
@@ -426,10 +444,9 @@ pub async fn handle_kiro_social_callback(
         account.usage_data = Some(usage_result.usage_data);
         update_account_status(&mut account, usage_result.is_banned, usage_result.is_auth_error);
 
-        // 为所有新账号生成 machine_id
-        use crate::commands::machine_guid::get_machine_id;
-        account.machine_id = Some(get_machine_id());
-        log::info!("Generated machine_id for new {} account", pending.provider);
+        // 为所有新账号生成唯一的 machine_id（每个账号独立 UUID，避免隐私泄露）
+        account.machine_id = Some(pending.machineid.clone());
+        log::info!("Generated unique machine_id for new {} account", pending.provider);
         
         store.accounts.insert(0, account.clone());
         account

--- a/src-tauri/src/commands/common.rs
+++ b/src-tauri/src/commands/common.rs
@@ -4,6 +4,7 @@ use crate::core::account::Account;
 use crate::auth::providers::{
     AuthProvider, IdcProvider, RefreshMetadata, SocialProvider,
 };
+use crate::commands::machine_guid::generate_random_machine_id;
 use crate::utils::client_id_hash::calculate_client_id_hash;
 use std::sync::{Mutex, MutexGuard};
 
@@ -128,6 +129,27 @@ pub fn resolve_default_profile_arn(provider: Option<&str>) -> &'static str {
     }
 }
 
+/// Generate an account-scoped machine ID.
+///
+/// This deliberately does not read the system machine GUID: stored accounts must
+/// have stable IDs without linking multiple accounts on the same host.
+pub fn generate_account_machine_id() -> String {
+    generate_random_machine_id()
+}
+
+pub fn account_machine_id_or_new(machine_id: &Option<String>) -> String {
+    machine_id
+        .clone()
+        .filter(|id| !id.trim().is_empty())
+        .unwrap_or_else(generate_account_machine_id)
+}
+
+pub fn ensure_account_machine_id(account: &mut Account) -> String {
+    let machine_id = account_machine_id_or_new(&account.machine_id);
+    account.machine_id = Some(machine_id.clone());
+    machine_id
+}
+
 // ===== Mutex 锁辅助 =====
 
 /// 锁定 AppState 中任意 `Mutex<T>`，统一错误信息
@@ -159,7 +181,7 @@ pub fn find_account_by_id(
 /// 调用 Kiro Q API 需要的三件套：machine_id / region / profile_arn
 ///
 /// 解析规则：
-/// - machine_id：账号自带（非空）→ 否则系统 machine_guid
+/// - machine_id：账号自带（非空）→ 否则生成账号独立 ID
 /// - profile_arn：Enterprise → None；其他账号自带 → 否则 provider 默认 ARN
 /// - region：profile_arn 解析出来的 region 优先 → 账号 region → fallback
 pub struct KiroCallContext {
@@ -170,13 +192,8 @@ pub struct KiroCallContext {
 
 pub fn resolve_kiro_call_context(account: &Account, fallback_region: &str) -> KiroCallContext {
     use crate::clients::http_client::resolve_kiro_upstream_region;
-    use crate::commands::machine_guid::get_machine_id;
 
-    let machine_id = account
-        .machine_id
-        .clone()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(get_machine_id);
+    let machine_id = account_machine_id_or_new(&account.machine_id);
 
     let profile_arn = match account.provider.as_deref() {
         Some("Enterprise") => None,
@@ -358,7 +375,7 @@ pub async fn refresh_token_by_provider(account: &Account) -> Result<RefreshResul
     } else {
         let metadata = RefreshMetadata {
             profile_arn: account.profile_arn.clone(),
-            machine_id: account.machine_id.clone(),
+            machine_id: Some(account_machine_id_or_new(&account.machine_id)),
             ..Default::default()
         };
         let social_provider = SocialProvider::new(provider);
@@ -383,13 +400,8 @@ pub async fn get_usage_by_account(
 ) -> Result<UsageResult, String> {
     use crate::clients::http_client::resolve_kiro_upstream_region;
     use crate::clients::kiro_q_client::KiroQClient;
-    use crate::commands::machine_guid::get_machine_id;
 
-    let machine_id = account
-        .machine_id
-        .clone()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(get_machine_id);
+    let machine_id = account_machine_id_or_new(&account.machine_id);
 
     let region = resolve_kiro_upstream_region(
         account.profile_arn.as_deref(),
@@ -467,15 +479,22 @@ pub async fn get_usage_by_provider(
     provider: &str,
     access_token: &str,
 ) -> Result<UsageResult, String> {
-    use crate::commands::machine_guid::get_machine_id;
+    let machine_id = generate_account_machine_id();
+    get_usage_by_provider_with_machine_id(provider, access_token, &machine_id).await
+}
 
+pub async fn get_usage_by_provider_with_machine_id(
+    provider: &str,
+    access_token: &str,
+    machine_id: &str,
+) -> Result<UsageResult, String> {
     // 为了兼容旧调用，创建一个临时账号对象
     let mut temp_account = crate::core::account::Account::new(
         String::new(),
         String::new(),
     );
     temp_account.provider = Some(provider.to_string());
-    temp_account.machine_id = Some(get_machine_id());
+    temp_account.machine_id = Some(machine_id.to_string());
 
     // 根据 provider 设置 auth_method（profile_arn 由 get_usage_by_account 统一处理）
     if provider == "BuilderId" || provider == "Enterprise" {

--- a/src-tauri/src/commands/kiro_cli_cmd.rs
+++ b/src-tauri/src/commands/kiro_cli_cmd.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::needless_pass_by_value)] // Tauri 命令需要按值传递参数
 
 use crate::core::account::Account;
-use crate::commands::common::{extract_user_info, get_usage_by_provider};
+use crate::commands::common::{
+    ensure_account_machine_id, extract_user_info, generate_account_machine_id,
+    get_usage_by_account, get_usage_by_provider_with_machine_id,
+};
 use crate::kiro::cli::read_kiro_cli_accounts;
 use crate::state::AppState;
 use crate::utils::client_id_hash::{extract_start_url_from_client_secret, normalize_start_url};
@@ -177,7 +180,26 @@ pub async fn import_from_kiro_cli(
 
     // 2. 调用统一的 getUsageLimits API 获取配额
     let provider = determine_provider(cli_account);
-    let usage_result = get_usage_by_provider(&provider, &cli_account.access_token).await;
+    let account_machine_id = {
+        let store = lock_account_store(&state.store)?;
+        store
+            .accounts
+            .iter()
+            .find(|account| account.refresh_token.as_ref() == Some(&cli_account.refresh_token))
+            .and_then(|account| {
+                account
+                    .machine_id
+                    .clone()
+                    .filter(|id| !id.trim().is_empty())
+            })
+            .unwrap_or_else(generate_account_machine_id)
+    };
+    let usage_result = get_usage_by_provider_with_machine_id(
+        &provider,
+        &cli_account.access_token,
+        &account_machine_id,
+    )
+    .await;
 
     let (email, user_id, usage_data, is_banned, is_auth_error) = match usage_result {
         Ok(result) => {
@@ -281,13 +303,14 @@ pub async fn import_from_kiro_cli(
         account
             .machine_id
             .clone_from(&store.accounts[idx].machine_id);
+        if account.machine_id.as_ref().is_none_or(|id| id.trim().is_empty()) {
+            account.machine_id = Some(account_machine_id);
+        }
         account.id.clone_from(&store.accounts[idx].id);
         store.accounts[idx] = account.clone();
     } else {
         // 新账号，生成 machine_id
-        if account.machine_id.is_none() {
-            account.machine_id = Some(uuid::Uuid::new_v4().to_string().to_lowercase());
-        }
+        account.machine_id = Some(account_machine_id);
         store.accounts.push(account.clone());
     }
 
@@ -347,7 +370,7 @@ pub async fn switch_to_cli_account(
     };
 
     // 2. 切号前刷新 token（确保写入的是有效 token）
-    let refreshed_account = if account.refresh_token.is_some() {
+    let mut refreshed_account = if account.refresh_token.is_some() {
         log::info!("[CLI Switch] 切号前刷新 token...");
         match crate::commands::common::refresh_token_by_provider(&account).await {
             Ok(refresh_result) => {
@@ -377,15 +400,34 @@ pub async fn switch_to_cli_account(
     } else {
         account
     };
+    let generated_machine_id = if refreshed_account
+        .machine_id
+        .as_ref()
+        .is_none_or(|id| id.trim().is_empty())
+    {
+        Some(ensure_account_machine_id(&mut refreshed_account))
+    } else {
+        None
+    };
+    if let Some(machine_id) = generated_machine_id {
+        let mut store = lock_account_store(&state.store)?;
+        if let Some(a) = store.accounts.iter_mut().find(|a| a.id == account_id) {
+            if a.machine_id.as_ref().is_none_or(|id| id.trim().is_empty()) {
+                a.machine_id = Some(machine_id);
+                store.save_to_file();
+            }
+        }
+    }
 
     // 3. 切号后立即获取配额检测封禁状态
-    let provider = refreshed_account.provider.as_ref()
-        .ok_or("账号缺少 provider 字段")?;
+    if refreshed_account.provider.is_none() {
+        return Err("账号缺少 provider 字段".to_string());
+    }
     let access_token = refreshed_account.access_token.as_ref()
         .ok_or("账号缺少 access_token")?;
 
     log::info!("[CLI Switch] 切号后检测账号状态...");
-    match get_usage_by_provider(provider, access_token).await {
+    match get_usage_by_account(&refreshed_account, access_token).await {
         Ok(usage_result) => {
             // 更新账号状态（包括封禁检测）
             let mut store = lock_account_store(&state.store)?;

--- a/src-tauri/src/commands/machine_guid/mod.rs
+++ b/src-tauri/src/commands/machine_guid/mod.rs
@@ -13,7 +13,7 @@ mod macos;
 mod windows;
 
 pub use types::SystemMachineInfo;
-pub use utils::{generate_random_machine_id, get_machine_id};
+pub use utils::generate_random_machine_id;
 
 #[cfg(target_os = "linux")]
 use linux as platform;

--- a/src-tauri/src/commands/machine_guid/utils.rs
+++ b/src-tauri/src/commands/machine_guid/utils.rs
@@ -25,20 +25,6 @@ pub fn generate_random_machine_id() -> String {
     Uuid::new_v4().to_string().to_lowercase()
 }
 
-pub fn get_machine_id() -> String {
-    #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-    {
-        super::platform::get_system_machine_guid_inner()
-            .ok()
-            .and_then(|i| i.machine_guid)
-            .unwrap_or_else(generate_random_machine_id)
-    }
-    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-    {
-        generate_random_machine_id()
-    }
-}
-
 pub fn is_valid_machine_id(id: &str) -> bool {
     let lower = id.to_lowercase();
     UUID_REGEX.is_match(&lower) || HEX32_REGEX.is_match(&lower)
@@ -59,5 +45,4 @@ pub fn format_as_uuid(hex: &str) -> String {
         &c[20..32]
     )
 }
-
 

--- a/src-tauri/src/core/account.rs
+++ b/src-tauri/src/core/account.rs
@@ -419,6 +419,13 @@ fn normalize_accounts(accounts: Vec<Account>) -> (Vec<Account>, bool) {
         normalized.push(account);
     }
 
+    for account in &mut normalized {
+        if !has_value(account.machine_id.as_ref()) {
+            account.machine_id = Some(Uuid::new_v4().to_string().to_lowercase());
+            changed = true;
+        }
+    }
+
     (normalized, changed)
 }
 
@@ -879,7 +886,10 @@ mod tests {
 
         let (normalized, changed) = normalize_accounts(vec![social, idc]);
 
-        assert!(!changed);
+        assert!(changed);
         assert_eq!(normalized.len(), 2);
+        assert!(normalized
+            .iter()
+            .all(|account| account.machine_id.as_ref().is_some_and(|id| !id.trim().is_empty())));
     }
 }

--- a/src-tauri/src/core/account.rs
+++ b/src-tauri/src/core/account.rs
@@ -426,6 +426,36 @@ fn normalize_accounts(accounts: Vec<Account>) -> (Vec<Account>, bool) {
         }
     }
 
+    let mut machine_id_counts = std::collections::HashMap::<String, usize>::new();
+    for account in &normalized {
+        if let Some(machine_id) = account.machine_id.as_deref() {
+            let normalized_id = machine_id.trim().to_lowercase();
+            if !normalized_id.is_empty() {
+                *machine_id_counts.entry(normalized_id).or_default() += 1;
+            }
+        }
+    }
+
+    for account in &mut normalized {
+        let is_duplicate = account
+            .machine_id
+            .as_deref()
+            .map(|machine_id| {
+                let normalized_id = machine_id.trim().to_lowercase();
+                machine_id_counts
+                    .get(&normalized_id)
+                    .copied()
+                    .unwrap_or_default()
+                    > 1
+            })
+            .unwrap_or(false);
+
+        if is_duplicate {
+            account.machine_id = Some(Uuid::new_v4().to_string().to_lowercase());
+            changed = true;
+        }
+    }
+
     (normalized, changed)
 }
 
@@ -891,5 +921,24 @@ mod tests {
         assert!(normalized
             .iter()
             .all(|account| account.machine_id.as_ref().is_some_and(|id| !id.trim().is_empty())));
+    }
+
+    #[test]
+    fn normalize_accounts_rotates_duplicate_machine_ids() {
+        let mut first = Account::new("first@example.com".to_string(), "first".to_string());
+        first.user_id = Some("user-1".to_string());
+        first.machine_id = Some("duplicate-machine".to_string());
+
+        let mut second = Account::new("second@example.com".to_string(), "second".to_string());
+        second.user_id = Some("user-2".to_string());
+        second.machine_id = Some("duplicate-machine".to_string());
+
+        let (normalized, changed) = normalize_accounts(vec![first, second]);
+
+        assert!(changed);
+        assert_eq!(normalized.len(), 2);
+        assert_ne!(normalized[0].machine_id, normalized[1].machine_id);
+        assert_ne!(normalized[0].machine_id.as_deref(), Some("duplicate-machine"));
+        assert_ne!(normalized[1].machine_id.as_deref(), Some("duplicate-machine"));
     }
 }

--- a/src-tauri/src/gateway/proxy.rs
+++ b/src-tauri/src/gateway/proxy.rs
@@ -22,10 +22,9 @@ use tokio_stream::wrappers::ReceiverStream;
 use crate::{
     core::account::{Account, AccountStore},
     commands::common::{
-        get_usage_by_provider, is_token_expiring_soon,
+        account_machine_id_or_new, get_usage_by_account, is_token_expiring_soon,
         refresh_token_by_provider, resolve_default_profile_arn, update_account_status, RefreshResult,
     },
-    commands::machine_guid::get_machine_id,
     clients::{
         http_client::{
             build_kiro_custom_user_agent, build_q_service_url,
@@ -70,6 +69,7 @@ struct UpstreamCredentials {
     provider: Option<String>,
     region: String,
     source_label: String,
+    machine_id: String,
     user_agent: String,
     #[allow(dead_code)]
     auth_method: Option<String>,
@@ -294,7 +294,7 @@ async fn get_available_models_for_upstream(
     let response = client
         .list_available_models(
             &upstream.access_token,
-            &get_machine_id(),
+            &upstream.machine_id,
             &upstream.region,
             upstream.profile_arn.as_deref(),
             None, // model_provider
@@ -2236,6 +2236,7 @@ async fn resolve_managed_account_credentials(
                     provider: account.provider.clone(),
                     region: ctx.region,
                     source_label: format_managed_upstream_source(&state.config, &account),
+                    machine_id: ctx.machine_id.clone(),
                     user_agent: build_kiro_custom_user_agent(&ctx.machine_id),
                     auth_method: account.auth_method.clone(),
                     send_opt_out: should_send_codewhisperer_optout(),
@@ -2246,8 +2247,7 @@ async fn resolve_managed_account_credentials(
 
     match refresh_token_by_provider(&account).await {
         Ok(refresh) => {
-            let provider = account.provider.as_deref().unwrap_or("Google").to_string();
-            let usage_result = get_usage_by_provider(&provider, &refresh.access_token).await;
+            let usage_result = get_usage_by_account(&account, &refresh.access_token).await;
             let mut usage_data = None;
             let mut is_banned = false;
             let mut is_auth_error = false;
@@ -2295,11 +2295,7 @@ async fn resolve_managed_account_credentials(
             let response_time_ms = request_start.elapsed().as_millis() as u64;
             state.load_balancer.record_success(&account.id, response_time_ms).await;
 
-            let machine_id = account
-                .machine_id
-                .clone()
-                .filter(|value| !value.trim().is_empty())
-                .unwrap_or_else(get_machine_id);
+            let machine_id = account_machine_id_or_new(&account.machine_id);
             let profile_arn = match account.provider.as_deref() {
                 Some("Enterprise") => None,
                 provider => refresh.profile_arn.or_else(|| account.profile_arn.clone())
@@ -2317,6 +2313,7 @@ async fn resolve_managed_account_credentials(
                 provider: account.provider.clone(),
                 region,
                 source_label: format_managed_upstream_source(config, &account),
+                machine_id: machine_id.clone(),
                 user_agent: build_kiro_custom_user_agent(&machine_id),
                 auth_method: account.auth_method.clone(),
                 send_opt_out: should_send_codewhisperer_optout(),
@@ -5099,6 +5096,7 @@ mod tests {
             provider: None,
             region: "us-east-1".to_string(),
             source_label: "single:test".to_string(),
+            machine_id: "machine-123".to_string(),
             user_agent: "KiroIDE 0.11.34 machine-123".to_string(),
             auth_method: Some("external_idp".to_string()),
             send_opt_out: true,
@@ -5165,6 +5163,7 @@ mod tests {
             provider: None,
             region: "us-east-1".to_string(),
             source_label: "single:test".to_string(),
+            machine_id: "machine-456".to_string(),
             user_agent: "KiroIDE 0.11.34 machine-456".to_string(),
             auth_method: Some("social".to_string()),
             send_opt_out: true,
@@ -5209,6 +5208,7 @@ mod tests {
             provider: None,
             region: "us-east-1".to_string(),
             source_label: "single:test".to_string(),
+            machine_id: "machine-789".to_string(),
             user_agent: "KiroIDE 0.11.34 machine-789".to_string(),
             auth_method: Some("social".to_string()),
             send_opt_out: true,
@@ -5243,6 +5243,7 @@ mod tests {
             provider: Some("Internal".to_string()),
             region: "us-east-1".to_string(),
             source_label: "single:test".to_string(),
+            machine_id: "machine-999".to_string(),
             user_agent: "KiroIDE 0.11.34 machine-999".to_string(),
             auth_method: Some("IdC".to_string()),
             send_opt_out: true,
@@ -5278,6 +5279,7 @@ mod tests {
                 provider: Some(provider.to_string()),
                 region: "us-east-1".to_string(),
                 source_label: "single:test".to_string(),
+                machine_id: "machine-1000".to_string(),
                 user_agent: "KiroIDE 0.11.34 machine-1000".to_string(),
                 auth_method: Some("IdC".to_string()),
                 send_opt_out: true,


### PR DESCRIPTION
## Summary

Fixes a privacy bug where multiple kiro-account-manager accounts on the same machine shared identical `machineId` values. This leak occurred because all accounts were using the system's machine GUID, allowing Kiro to correlate accounts belonging to the same user.

## Problem

When managing multiple Kiro accounts, each account was assigned the same `machineId` - the system's machine GUID retrieved via `get_machine_id()`. This identifier is:

1. **Sent in every request** - Embedded in the `User-Agent` header (`KiroIDE-0.6.18-{machineId}`)
2. **Sent during authentication** - Included in login requests to Kiro's auth service
3. **Sent in API calls** - Included in usage checks, quota checks, and all gateway requests
4. **Persistent across account switches** - Remained constant for all accounts on the same machine

This allowed Kiro's backend to:
- Correlate multiple accounts as belonging to the same physical machine/user
- Potentially flag or limit accounts that appear to be controlled by a single entity
- Defeat the purpose of account isolation

## Solution

Generate a **unique UUID v4** for each account independently, rather than reusing the system GUID. The fix:

- **Per-account machine IDs**: Each account gets its own random UUID on creation
- **Consistent usage**: The same account-specific `machineId` is used across:
  - Authentication (login, token exchange)
  - Usage/quota checks
  - CLI import and account switching
  - Gateway proxy requests
- **Legacy migration**: Existing accounts without a `machineId` are backfilled with unique UUIDs during store normalization

## Changes

**10 files changed, 283 insertions(+), 161 deletions(-)**

### Core changes:
- `src-tauri/src/commands/account_cmd.rs` - Use per-account IDs for CLI and import flows
- `src-tauri/src/commands/auth_cmd.rs` - Generate unique IDs for new social/enterprise logins
- `src-tauri/src/commands/common.rs` - Add `generate_account_machine_id()` helper
- `src-tauri/src/commands/kiro_cli_cmd.rs` - Use account IDs for CLI token checks
- `src-tauri/src/commands/machine_guid/utils.rs` - Remove system GUID usage
- `src-tauri/src/core/account.rs` - Add machine ID normalization to backfill legacy accounts
- `src-tauri/src/gateway/proxy.rs` - Use account-scoped IDs in gateway user-agent headers

## Testing

- Verified that new accounts receive unique UUID v4 identifiers
- Confirmed that legacy accounts are migrated with unique IDs
- Verified that each account uses its own `machineId` in all API requests