### PR TITLE
fix: 加固账号导入/提权/OAuth 回调的几处安全与健壮性问题

### DIFF
--- a/src-tauri/src/commands/machine_guid/mod.rs
+++ b/src-tauri/src/commands/machine_guid/mod.rs
@@ -81,23 +81,33 @@ pub async fn restart_as_admin(app: tauri::AppHandle) -> Result<(), String> {
 
         let exe_path = std::env::current_exe().map_err(|e| format!("获取程序路径失败: {e}"))?;
 
-        // 使用 PowerShell 的 Start-Process -Verb RunAs 以管理员权限启动
-        let _status = Command::new("powershell")
+        // 使用 PowerShell 的 Start-Process -Verb RunAs 以管理员权限启动。
+        // M13:旧实现 spawn 后硬睡 500ms 就无条件 app.exit(0)——若用户在 UAC 弹窗点了
+        // "否"(或提权延迟),提权进程从未起来,旧进程却已退出,应用直接消失(假死)。
+        // 改用阻塞 output():Start-Process(不带 -Wait)会在提权进程一启动就返回,UAC 被
+        // 拒绝时会抛出终止错误使 PowerShell 非零退出。据此确认提权成功后再退旧进程,
+        // 失败则原样返回错误、不退出,让用户可重试。
+        let output = Command::new("powershell")
             .args([
                 "-NoProfile",
                 "-Command",
                 &format!(
-                    "Start-Process -FilePath '{}' -Verb RunAs",
+                    "$ErrorActionPreference='Stop'; Start-Process -FilePath '{}' -Verb RunAs",
                     exe_path.display().to_string().replace('\'', "''")
                 ),
             ])
-            .spawn()
+            .output()
             .map_err(|e| format!("启动管理员进程失败: {e}"))?;
 
-        // 等待一小段时间确保新进程启动
-        std::thread::sleep(std::time::Duration::from_millis(500));
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "以管理员权限启动失败(可能是取消了 UAC 提权): {}",
+                stderr.trim()
+            ));
+        }
 
-        // 退出当前应用
+        // 提权进程已确认启动,再退出当前进程。
         app.exit(0);
         Ok(())
     }
@@ -108,16 +118,27 @@ pub async fn restart_as_admin(app: tauri::AppHandle) -> Result<(), String> {
 
         let exe_path = std::env::current_exe().map_err(|e| format!("获取程序路径失败: {e}"))?;
 
-        // 尝试使用 pkexec
-        let result = Command::new("pkexec").arg(&exe_path).spawn();
+        // 尝试使用 pkexec。pkexec 会作为提权进程的父进程一直存活(不能用阻塞 output()
+        // 等它,那会挂到 app 退出),所以 spawn 后短暂 try_wait 探测:若 polkit 授权被取消,
+        // pkexec 会很快以非零码退出——此时不退出旧进程,返回错误让用户重试(M13)。
+        let mut child = match Command::new("pkexec").arg(&exe_path).spawn() {
+            Ok(child) => child,
+            Err(_) => {
+                return Err("请使用 sudo 或 pkexec 手动以 root 权限运行程序".to_string());
+            }
+        };
 
-        match result {
-            Ok(_) => {
-                std::thread::sleep(std::time::Duration::from_millis(500));
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        match child.try_wait() {
+            // 已退出且非成功 = 授权被取消 / 提权失败,别退当前进程
+            Ok(Some(status)) if !status.success() => {
+                Err("以管理员权限启动失败(可能是取消了授权),请重试或用 sudo 手动运行".to_string())
+            }
+            // 仍在运行(提权进程正常拉起,pkexec 作为父进程存活)= 成功,退出旧进程
+            _ => {
                 app.exit(0);
                 Ok(())
             }
-            Err(_) => Err("请使用 sudo 或 pkexec 手动以 root 权限运行程序".to_string()),
         }
     }
 

--- a/src-tauri/src/core/deep_link_handler.rs
+++ b/src-tauri/src/core/deep_link_handler.rs
@@ -40,10 +40,13 @@ impl DeepLinkCallbackWaiter {
 
     /// 等待回调结果
     pub fn wait_for_callback(&self) -> Result<OAuthCallbackResult, String> {
+        // 锁中毒时恢复 guard 而非 panic(M5):这些锁保护的只是一个 Option 槽,
+        // 持锁线程 panic 不会破坏其内部不变量,直接取回数据继续即可。否则一次 panic
+        // 会永久毒化该锁,让此后所有 login/deep_link 全部 panic 直到重启应用。
         let rx = self
             .result_rx
             .lock()
-            .expect("Failed to acquire result_rx lock")
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
             .take()
             .ok_or("Callback channel already consumed")?;
 
@@ -67,9 +70,10 @@ pub fn register_waiter(state: &str) -> DeepLinkCallbackWaiter {
 
     // 存储发送端
     let storage = PENDING_SENDER.get_or_init(|| Mutex::new(None));
+    // 锁中毒时恢复 guard 而非 panic(M5),见 wait_for_callback 注释。
     let mut guard = storage
         .lock()
-        .expect("Failed to acquire pending sender lock");
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     if let Some((_state, previous_tx)) = guard.take() {
         let _ = previous_tx.send(Err("登录已取消".to_string()));
     }
@@ -86,9 +90,10 @@ pub fn cancel_waiter() -> bool {
         return false;
     };
 
+    // 锁中毒时恢复 guard 而非 panic(M5),见 wait_for_callback 注释。
     let mut guard = storage
         .lock()
-        .expect("Failed to acquire pending sender lock");
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let Some((_state, tx)) = guard.take() else {
         return false;
     };
@@ -126,9 +131,10 @@ pub fn handle_deep_link(url: &str) -> (bool, bool) {
         return (false, false);
     };
 
+    // 锁中毒时恢复 guard 而非 panic(M5),见 wait_for_callback 注释。
     let mut guard = storage
         .lock()
-        .expect("Failed to acquire pending sender lock");
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let Some((expected_state, tx)) = guard.take() else {
         log::warn!("[deep_link] No pending login waiter");
         return (false, false);

--- a/src-tauri/src/kiro/settings/skills.rs
+++ b/src-tauri/src/kiro/settings/skills.rs
@@ -124,6 +124,45 @@ impl SkillsManager {
         Ok(())
     }
 
+    /// 校验用户传入的 git 分支名,防止把 `--upload-pack=...` 之类的选项或控制字符
+    /// 当作 `git clone --branch <arg>` 的参数注入(H7)。与 powers.rs::validate_branch_name
+    /// 保持同源规则:拒绝 `-` 开头、空白/NUL、git refname 非法字符及危险后缀。
+    fn validate_branch_name(branch: &str) -> Result<(), String> {
+        if branch.is_empty() {
+            return Ok(());
+        }
+        if branch.starts_with('-') {
+            return Err("分支名非法".to_string());
+        }
+        if branch.contains('\0')
+            || branch.contains(' ')
+            || branch.contains('\t')
+            || branch.contains('\n')
+            || branch.contains('\r')
+        {
+            return Err("分支名非法".to_string());
+        }
+        if branch.contains("..")
+            || branch.contains('~')
+            || branch.contains('^')
+            || branch.contains(':')
+            || branch.contains('?')
+            || branch.contains('*')
+            || branch.contains('\\')
+        {
+            return Err("分支名非法".to_string());
+        }
+        if branch.ends_with('.')
+            || branch.ends_with('/')
+            || branch.ends_with(".lock")
+            || branch.contains("@{")
+            || branch.contains("//")
+        {
+            return Err("分支名非法".to_string());
+        }
+        Ok(())
+    }
+
     fn safe_skill_dir(base_dir: &Path, name: &str) -> Result<PathBuf, String> {
         Self::validate_skill_name(name)?;
         let candidate = base_dir.join(name);
@@ -281,6 +320,7 @@ impl SkillsManager {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .unwrap_or("main");
+        Self::validate_branch_name(branch_name)?;
 
         let clone_result = Command::new("git")
             .args([


### PR DESCRIPTION
## 问题
用的时候碰到几个安全和健壮性的点

1 Skill 从 GitHub 导入有命令注入面 skills.rs import_from_github 把用户填的分支名直接拼进 git clone --branch 没校验 填 --upload-pack= 会被 git 当选项 其实 powers.rs 里早有 validate_branch_name 只是 skills 漏了
2 提权重启会假死 restart_as_admin spawn 后硬 sleep 500ms 就 app.exit 用户 UAC 点否 提权进程没起来旧进程却退了 应用直接消失
3 OAuth 回调的锁中毒后登录永久坏 deep_link_handler 几处 .lock().expect 一次 panic 毒化后所有 login 跟着 panic 只能重启

## 改动
- kiro/settings/skills.rs clone 前加分支名校验 规则跟 powers.rs 那份一致
- commands/machine_guid/mod.rs 确认提权起来了再退旧进程 Windows 阻塞 Start-Process + ErrorActionPreference=Stop Linux try_wait 探测 失败就报错不退出
- core/deep_link_handler.rs 4 处 expect 改 PoisonError::into_inner 这些锁只保护 Option 槽 恢复安全

## 测试
cargo check test 无新增失败
分支名校验 --upload-pack=x 带空格或 .. 的都会被拒
提权 UAC 取消后应用不再消失 而是报错留在原地