### PR TITLE
fix: 修复非 us-east-1 企业 IdC 号导入后失效刷新 400

### DIFF
--- a/src-tauri/src/commands/account_cmd.rs
+++ b/src-tauri/src/commands/account_cmd.rs
@@ -936,20 +936,36 @@ struct IdcAccountParams {
 /// 内部函数：添加 `IdC` 账号（BuilderId 或 Enterprise）
 async fn add_account_by_idc_internal(
     state: State<'_, AppState>,
-    params: IdcAccountParams,
+    mut params: IdcAccountParams,
 ) -> Result<AddAccountResult, String> {
-    let is_enterprise = params.provider_id == "Enterprise";
-
-    // 从 clientSecret JWT 中提取 startUrl（如果未提供）。
+    // 从 clientSecret JWT 中提取 startUrl（如果前端没显式传）。
+    // 关键：**不管前端判 BuilderId 还是 Enterprise 都尝试提取**。真实企业号的 startUrl
+    // 藏在 clientSecret 的 JWT payload（base64，明文搜不到 initiateLoginUri），前端无法
+    // 可靠区分，常把企业号误判成 BuilderId。这里用 extract_start_url_from_client_secret
+    // 正确解码 JWT，只要提取到 start_url，就说明它是真正的企业 IdC 号。
     // 两条来源都过 normalize_start_url 去尾斜杠：params.start_url 可能由前端带斜杠传入，
     // JWT 真相源虽已规范化，这里统一兜底，保证落进 account.start_url 的永远是无斜杠规范形。
     let start_url = if let Some(ref url) = params.start_url {
         Some(normalize_start_url(url))
-    } else if is_enterprise {
-        extract_start_url_from_client_secret(&params.client_secret)
     } else {
-        None
+        extract_start_url_from_client_secret(&params.client_secret)
     };
+
+    // 依据「实际拿到的 start_url」纠正 provider：前端可能误判 BuilderId，但只要 clientSecret
+    // 里解出了非 BuilderId 默认域的 start_url，就是企业号。BuilderId 的公共 start_url 是
+    // view.awsapps.com，企业号是自己的 d-xxx / xxx.awsapps.com 实例。空串先过滤掉再判。
+    let is_enterprise = params.provider_id == "Enterprise"
+        || start_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+            .is_some_and(|u| !crate::commands::common::is_builder_id_start_url(u));
+
+    // 纠正 provider_id：前端可能把企业号误判成 BuilderId，这里按 JWT 解出的真相回正，
+    // 使后续刷新（IdcProvider::new）和落库（account.provider）都用正确的 Enterprise。
+    if is_enterprise {
+        params.provider_id = "Enterprise".to_string();
+    }
 
     // BuilderId 和 Enterprise 都使用默认 region（如果未提供）
     let region = params.region.unwrap_or_else(|| "us-east-1".to_string());

--- a/src/components/features/AccountManager/ImportAccountModal.tsx
+++ b/src/components/features/AccountManager/ImportAccountModal.tsx
@@ -111,14 +111,18 @@ function validateAccount(item: any, index: number) {
     return { valid: false, errors, type: null }
   }
 
-  // Enterprise 账号必须提供 region 和 startUrl
+  // Enterprise 账号校验放宽：
+  // - region 接受 authRegion（企业号 region 常在 authRegion 而非顶层 region）
+  // - startUrl 不再强制：真实企业号 startUrl 藏在 clientSecret 的 JWT 里，后端会解码提取，
+  //   只要有 clientSecret 就不拦（clientId/clientSecret 前面已按 IdC 校验过）
   if (normalizedProvider === 'Enterprise') {
-    if (!item.region || !item.region.trim()) {
-      errors.push(`第 ${index + 1} 条: Enterprise 账号必须提供 region 字段`)
+    const enterpriseRegion = item.authRegion ?? item.auth_region ?? item.region
+    if (!enterpriseRegion || !String(enterpriseRegion).trim()) {
+      errors.push(`第 ${index + 1} 条: Enterprise 账号必须提供 region 字段（region 或 authRegion）`)
       return { valid: false, errors, type: null }
     }
-    if (!item.startUrl || !item.startUrl.trim()) {
-      errors.push(`第 ${index + 1} 条: Enterprise 账号必须提供 startUrl 字段`)
+    if ((!item.startUrl || !item.startUrl.trim()) && !item.clientSecret) {
+      errors.push(`第 ${index + 1} 条: Enterprise 账号必须提供 startUrl 或 clientSecret`)
       return { valid: false, errors, type: null }
     }
   }
@@ -331,7 +335,8 @@ function ImportAccountModal({ onClose, onSuccess, onNavigate }: ImportAccountMod
             refreshToken: item.refreshToken,
             clientId: item.clientId,
             clientSecret: item.clientSecret,
-            region: item.region || null,
+            // 企业 IdC 号 region 在 authRegion（不是顶层 region），漏读会存成 us-east-1 → 刷新打错 oidc host → 400
+            region: (item.authRegion ?? item.auth_region ?? item.region) || null,
             machineId: item.machineId || null,
             accessToken: item.accessToken || null,
             password: item.password || null,
@@ -399,7 +404,8 @@ function ImportAccountModal({ onClose, onSuccess, onNavigate }: ImportAccountMod
             refreshToken: account.refreshToken,
             clientId: account.clientId,
             clientSecret: account.clientSecret,
-            region: account.region || null,
+            // 企业 IdC 号 region 在 authRegion（不是顶层 region），漏读会存成 us-east-1 → 刷新打错 oidc host → 400
+            region: (account.authRegion ?? account.auth_region ?? account.region) || null,
             machineId: null,
             accessToken: account.accessToken || null,
             password: null,


### PR DESCRIPTION
## 问题
非 us-east-1 的企业 IdC 号 如 eu-central-1 导入后显示失效 刷新报 400 invalid_request 三个原因叠加
- 前端只按顶层 startUrl 判 BuilderId/Enterprise 但真实企业号 startUrl 藏在 clientSecret 的 JWT payload 里 base64 明文搜不到 initiateLoginUri 企业号被误判成 BuilderId
- 被判 BuilderId 后后端只在 is_enterprise 时才从 clientSecret 提 start_url 导致 start_url 为空 刷新走公共 client 报 400
- 企业号 region 在 authRegion 字段而不是 region 前端只读 region 存成了 us-east-1 刷新打错 oidc host

## 改动
- 后端 add_account_by_idc 无条件用 extract_start_url_from_client_secret 解 JWT 提 start_url 解出非 BuilderId 默认域就判企业号并纠正 provider 为 Enterprise 刷新和落库都用纠正后的值
- 前端两个 IdC 导入分支 region 改读 authRegion 兜底 auth_region 再兜底 region
- 放宽 Enterprise 导入校验 region 接受 authRegion 有 clientSecret 就不强制填 startUrl

## 测试
cargo check 0 error 0 warning
tsc --noEmit 0 error
BuilderId 号解出 view.awsapps.com 或解不出都不会被误翻成 Enterprise 现有 BuilderId social 路径不受影响