### PR TITLE
fix: Enterprise getUsageLimits 使用 ListAvailableProfiles 解析真实 profileArn

### DIFF
--- a/src-tauri/src/auto_switch.rs
+++ b/src-tauri/src/auto_switch.rs
@@ -361,9 +361,48 @@ async fn resolve_current_account_by_usage(
             return None;
         }
     };
-    let regions = crate::clients::kiro_client::usage_limits_region_candidates(region, false);
+
+    // Enterprise IdC 本地 token 通常不带 profileArn，需 ListAvailableProfiles；
+    // Social/BuilderId 用本地或默认 ARN。
+    let mut profile_arn = local_token
+        .profile_arn
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let needs_profile_discovery =
+        local_token.auth_method.as_deref() == Some("IdC") && profile_arn.is_none();
+    let regions =
+        crate::clients::kiro_client::usage_limits_region_candidates(region, needs_profile_discovery);
+
+    if needs_profile_discovery {
+        match client
+            .resolve_enterprise_profile_arn(access_token, &regions)
+            .await
+        {
+            Ok(arn) => profile_arn = arn,
+            Err(e) => {
+                log::warn!("[AutoSwitch] ListAvailableProfiles 失败: {e}");
+            }
+        }
+    }
+    if profile_arn.is_none() {
+        profile_arn = Some(
+            match local_token.auth_method.as_deref() {
+                Some("social") => crate::commands::common::KIRO_SOCIAL_PROFILE_ARN,
+                _ => crate::commands::common::KIRO_BUILDER_ID_PROFILE_ARN,
+            }
+            .to_string(),
+        );
+    }
+
     let usage = match client
-        .get_usage_limits_with_region_fallback(access_token, &machine_id, &regions)
+        .get_usage_limits_with_region_fallback(
+            access_token,
+            &machine_id,
+            &regions,
+            profile_arn.as_deref(),
+        )
         .await
     {
         Ok((_region, data)) => data,

--- a/src-tauri/src/clients/kiro_client.rs
+++ b/src-tauri/src/clients/kiro_client.rs
@@ -45,12 +45,38 @@ fn build_kiro_management_service_url(region: &str) -> String {
     format!("https://{}", build_kiro_management_host(region))
 }
 
-fn build_get_usage_limits_url(region: &str) -> String {
+fn build_get_usage_limits_url(region: &str, profile_arn: Option<&str>) -> String {
     let base = build_kiro_management_service_url(region);
-    // getUsageLimits 不携带 profileArn：企业账号带了会 400（对齐 kiro.rs v0.6.11）
-    format!(
-        "{base}/getUsageLimits?isEmailRequired=true&origin=AI_EDITOR&resourceType=AGENTIC_REQUEST"
-    )
+    // 对齐真实 Kiro IDE：GetUsageLimits 带 profileArn。
+    // 企业号必须带 ListAvailableProfiles 返回的真实 ARN；带错（如 BuilderId 默认）会 400/403。
+    match profile_arn
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(profile_arn) => format!(
+            "{base}/getUsageLimits?isEmailRequired=true&origin=AI_EDITOR&profileArn={}&resourceType=AGENTIC_REQUEST",
+            urlencoding::encode(profile_arn)
+        ),
+        None => format!(
+            "{base}/getUsageLimits?isEmailRequired=true&origin=AI_EDITOR&resourceType=AGENTIC_REQUEST"
+        ),
+    }
+}
+
+/// 从 ListAvailableProfiles 响应中取第一个非空 profile ARN。
+pub fn first_profile_arn_from_list_response(value: &serde_json::Value) -> Option<String> {
+    value
+        .get("profiles")?
+        .as_array()?
+        .iter()
+        .find_map(|profile| {
+            profile
+                .get("arn")
+                .and_then(|arn| arn.as_str())
+                .map(str::trim)
+                .filter(|arn| !arn.is_empty())
+                .map(str::to_string)
+        })
 }
 
 /// 构造 getUsageLimits 的 region 尝试顺序：优先账号 region，企业号再回退常见 region。
@@ -168,16 +194,23 @@ impl KiroClient {
         Self { client }
     }
 
-    /// 统一的 getUsageLimits 接口（支持所有账号类型；URL 不带 profileArn）
+    /// 统一的 getUsageLimits 接口（支持所有账号类型）。
+    ///
+    /// `profile_arn`：BuilderId/Social 用解析后的 ARN；Enterprise 用账号保存值或
+    /// `ListAvailableProfiles` 发现的真实 ARN。勿对企业号套 BuilderId 默认 ARN。
     pub async fn get_usage_limits(
         &self,
         access_token: &str,
         machine_id: &str,
         region: &str,
+        profile_arn: Option<&str>,
     ) -> Result<serde_json::Value, String> {
-        let url = build_get_usage_limits_url(region);
+        let url = build_get_usage_limits_url(region, profile_arn);
 
-        log::info!("[GetUsageLimits] Request - region: {region}");
+        log::info!(
+            "[GetUsageLimits] Request - region: {region}, profileArn: {}",
+            profile_arn.unwrap_or("(none)")
+        );
 
         let request = with_kiro_runtime_management_headers(
             self.client.get(&url),
@@ -209,11 +242,12 @@ impl KiroClient {
         access_token: &str,
         machine_id: &str,
         regions: &[String],
+        profile_arn: Option<&str>,
     ) -> Result<(String, serde_json::Value), String> {
         let mut last_err = String::new();
         for region in regions {
             match self
-                .get_usage_limits(access_token, machine_id, region)
+                .get_usage_limits(access_token, machine_id, region, profile_arn)
                 .await
             {
                 Ok(v) => return Ok((region.clone(), v)),
@@ -227,6 +261,36 @@ impl KiroClient {
             }
         }
         Err(format!("所有 region 均失败: {last_err}"))
+    }
+
+    /// 按 region 候选列表解析 Enterprise 真实 profileArn（ListAvailableProfiles）。
+    ///
+    /// AUTH_ERROR / BANNED 直接返回；空 profiles 或其它错误则继续下一 region。
+    pub async fn resolve_enterprise_profile_arn(
+        &self,
+        access_token: &str,
+        regions: &[String],
+    ) -> Result<Option<String>, String> {
+        for region in regions {
+            match self.list_available_profiles(access_token, region).await {
+                Ok(value) => {
+                    if let Some(arn) = first_profile_arn_from_list_response(&value) {
+                        log::info!(
+                            "[ListAvailableProfiles] region {region} resolved profileArn: {arn}"
+                        );
+                        return Ok(Some(arn));
+                    }
+                    log::info!("[ListAvailableProfiles] region {region} returned empty profiles");
+                }
+                Err(e) if e.starts_with("AUTH_ERROR:") || e.starts_with("BANNED:") => {
+                    return Err(e);
+                }
+                Err(e) => {
+                    log::warn!("[ListAvailableProfiles] region {region} failed: {e}");
+                }
+            }
+        }
+        Ok(None)
     }
 
     /// ListAvailableModels 接口
@@ -393,10 +457,37 @@ mod tests {
     }
 
     #[test]
-    fn builds_get_usage_limits_url_without_profile_arn() {
+    fn builds_get_usage_limits_url_with_optional_profile_arn() {
         assert_eq!(
-            build_get_usage_limits_url("us-east-1"),
+            build_get_usage_limits_url("us-east-1", None),
             "https://management.us-east-1.kiro.dev/getUsageLimits?isEmailRequired=true&origin=AI_EDITOR&resourceType=AGENTIC_REQUEST"
+        );
+        assert_eq!(
+            build_get_usage_limits_url(
+                "us-east-1",
+                Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/AAAACCCCXXXX")
+            ),
+            "https://management.us-east-1.kiro.dev/getUsageLimits?isEmailRequired=true&origin=AI_EDITOR&profileArn=arn%3Aaws%3Acodewhisperer%3Aus-east-1%3A123456789012%3Aprofile%2FAAAACCCCXXXX&resourceType=AGENTIC_REQUEST"
+        );
+    }
+
+    #[test]
+    fn first_profile_arn_from_list_response_picks_first_non_empty() {
+        use super::first_profile_arn_from_list_response;
+
+        assert_eq!(
+            first_profile_arn_from_list_response(&serde_json::json!({
+                "profiles": [
+                    { "arn": "   " },
+                    { "arn": "arn:aws:codewhisperer:us-east-1:123456789012:profile/AAAACCCCXXXX", "profileName": "KiroProfile-us-east-1" }
+                ]
+            }))
+            .as_deref(),
+            Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/AAAACCCCXXXX")
+        );
+        assert_eq!(
+            first_profile_arn_from_list_response(&serde_json::json!({ "profiles": [] })),
+            None
         );
     }
 

--- a/src-tauri/src/commands/account_cmd.rs
+++ b/src-tauri/src/commands/account_cmd.rs
@@ -220,7 +220,15 @@ pub async fn sync_account(
             if let Some(ref refresh_token) = result.refresh_token {
                 a.refresh_token = Some(refresh_token.clone());
             }
-            a.profile_arn = result.profile_arn.clone();
+            // IdC/Enterprise refresh 通常不回 profileArn；勿用 None 覆盖已存真实 ARN
+            if result
+                .profile_arn
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|value| !value.is_empty())
+            {
+                a.profile_arn = result.profile_arn.clone();
+            }
             a.id_token = result.id_token.clone();
             a.sso_session_id = result.sso_session_id.clone();
             a.expires_at = Some(calc_expires_at(result.expires_in));

--- a/src-tauri/src/commands/account_cmd.rs
+++ b/src-tauri/src/commands/account_cmd.rs
@@ -151,8 +151,7 @@ pub async fn sync_account(
         );
     }
 
-    // 统一走 get_usage_by_account：getUsageLimits 不带 profileArn；
-    // Enterprise 还会按账号 region + us-east-1/eu-central-1 回退
+    // 统一走 get_usage_by_account：Enterprise 会先解析真实 profileArn 再查配额
     let mut usage_result = get_usage_by_account(&account, &access_token).await;
 
     let mut refresh_result: Option<RefreshResult> = None;
@@ -234,6 +233,13 @@ pub async fn sync_account(
 
         // 只有成功获取配额时才更新 usage_data 和 status
         if let Some(usage_data) = usage {
+            // Enterprise 首次同步时落库 ListAvailableProfiles 发现的 profileArn
+            if let Some(ref arn) = usage_data.resolved_profile_arn {
+                if a.profile_arn.as_deref().map(str::trim).unwrap_or("").is_empty() {
+                    a.profile_arn = Some(arn.clone());
+                }
+            }
+
             // 直接移动所有权，避免 clone
             a.usage_data = Some(usage_data.usage_data);
             update_account_status(a, usage_data.is_banned, usage_data.is_auth_error);
@@ -330,6 +336,11 @@ pub async fn get_usage_limits(
         }
 
         // 更新 usage_data 和 status
+        if let Some(ref arn) = usage.resolved_profile_arn {
+            if a.profile_arn.as_deref().map(str::trim).unwrap_or("").is_empty() {
+                a.profile_arn = Some(arn.clone());
+            }
+        }
         a.usage_data = Some(usage.usage_data);
         update_account_status(a, usage.is_banned, usage.is_auth_error);
 
@@ -515,11 +526,7 @@ pub async fn verify_account(
         Err(e) => {
             log::warn!("Failed to get usage in verify_account: {}", e);
             // 即使 getUsageLimits 失败，也能更新账号
-            crate::commands::common::UsageResult {
-                usage_data: serde_json::json!({}),
-                is_banned: false,
-                is_auth_error: false,
-            }
+            crate::commands::common::UsageResult::empty()
         }
     };
     let usage_data = usage_result.usage_data.clone();
@@ -779,20 +786,12 @@ pub async fn add_account_by_external_idp(
                 Ok(result) => result,
                 Err(e) => {
                     log::warn!("[external_idp] 取 usage 失败: {e}");
-                    crate::commands::common::UsageResult {
-                        usage_data: serde_json::json!({}),
-                        is_banned: false,
-                        is_auth_error: false,
-                    }
+                    crate::commands::common::UsageResult::empty()
                 }
             }
         }
         // 无 access_token 不 hard-fail，账号仍落库（usage 置空）
-        _ => crate::commands::common::UsageResult {
-            usage_data: serde_json::json!({}),
-            is_banned: false,
-            is_auth_error: false,
-        },
+        _ => crate::commands::common::UsageResult::empty(),
     };
 
     // 封禁账号直接报错（与 social / idc 一致）
@@ -1187,11 +1186,7 @@ async fn add_account_by_idc_internal(
             Err(e) => {
                 log::warn!("Failed to get usage in add_account_by_idc: {}", e);
                 // 即使 getUsageLimits 失败，也能保存账号
-                crate::commands::common::UsageResult {
-                    usage_data: serde_json::json!({}),
-                    is_banned: false,
-                    is_auth_error: false,
-                }
+                crate::commands::common::UsageResult::empty()
             }
         };
 
@@ -1232,11 +1227,7 @@ async fn add_account_by_idc_internal(
                     Err(e) => {
                         log::warn!("Failed to get usage after token refresh: {}", e);
                         // 即使 getUsageLimits 失败，也能保存账号
-                        crate::commands::common::UsageResult {
-                            usage_data: serde_json::json!({}),
-                            is_banned: false,
-                            is_auth_error: false,
-                        }
+                        crate::commands::common::UsageResult::empty()
                     }
                 };
                 let expires_at = calc_expires_at(auth_result.expires_in);
@@ -1287,11 +1278,7 @@ async fn add_account_by_idc_internal(
             Err(e) => {
                 log::warn!("Failed to get usage in add_account_by_idc: {}", e);
                 // 即使 getUsageLimits 失败，也能保存账号
-                crate::commands::common::UsageResult {
-                    usage_data: serde_json::json!({}),
-                    is_banned: false,
-                    is_auth_error: false,
-                }
+                crate::commands::common::UsageResult::empty()
             }
         };
 
@@ -1366,6 +1353,9 @@ async fn add_account_by_idc_internal(
             if sso_session_id.is_some() {
                 existing.sso_session_id = sso_session_id;
             }
+            if let Some(arn) = usage_result.resolved_profile_arn.clone() {
+                existing.profile_arn = Some(arn);
+            }
             existing.usage_data = Some(usage_result.usage_data);
             update_account_status(existing, usage_result.is_banned, usage_result.is_auth_error);
             existing.clone()
@@ -1386,6 +1376,7 @@ async fn add_account_by_idc_internal(
             account.start_url = start_url.clone();
             account.id_token = id_token;
             account.sso_session_id = sso_session_id;
+            account.profile_arn = usage_result.resolved_profile_arn.clone();
             account.usage_data = Some(usage_result.usage_data);
             update_account_status(
                 &mut account,

--- a/src-tauri/src/commands/auth_cmd.rs
+++ b/src-tauri/src/commands/auth_cmd.rs
@@ -354,11 +354,7 @@ async fn login_idc(
         Err(e) => {
             log::warn!("Failed to get usage for {}: {}", provider_id, e);
             // 即使 getUsageLimits 失败，也能保存账号
-            crate::commands::common::UsageResult {
-                usage_data: serde_json::json!({}),
-                is_banned: false,
-                is_auth_error: false,
-            }
+            crate::commands::common::UsageResult::empty()
         }
     };
 

--- a/src-tauri/src/commands/auth_cmd.rs
+++ b/src-tauri/src/commands/auth_cmd.rs
@@ -419,7 +419,12 @@ async fn login_idc(
         existing.start_url.clone_from(&auth_result.start_url); // 保存 start_url
         existing.sso_session_id = auth_result.sso_session_id;
         existing.id_token = auth_result.id_token;
-        existing.profile_arn = auth_result.profile_arn;
+        // IdC 登录结果通常无 profileArn；优先落库 usage 解析到的真实 ARN
+        existing.profile_arn = usage_result
+            .resolved_profile_arn
+            .clone()
+            .or(auth_result.profile_arn)
+            .or_else(|| existing.profile_arn.clone());
         existing.usage_data = Some(usage_result.usage_data);
         // machine_id 应该已经存在且被复用了，这里仅作兜底
         if existing.machine_id.as_ref().is_none_or(|id| id.trim().is_empty()) {
@@ -449,7 +454,10 @@ async fn login_idc(
         account.start_url.clone_from(&auth_result.start_url); // 保存 start_url
         account.sso_session_id = auth_result.sso_session_id;
         account.id_token = auth_result.id_token;
-        account.profile_arn = auth_result.profile_arn;
+        account.profile_arn = usage_result
+            .resolved_profile_arn
+            .clone()
+            .or(auth_result.profile_arn);
         account.usage_data = Some(usage_result.usage_data);
         update_account_status(
             &mut account,

--- a/src-tauri/src/commands/common.rs
+++ b/src-tauri/src/commands/common.rs
@@ -148,14 +148,15 @@ pub fn ensure_account_machine_id(account: &mut Account) -> String {
     machine_id
 }
 
-/// 统一的 profileArn 解析逻辑（用于 ListAvailableModels 等 API 调用）
+/// 统一的 profileArn 解析逻辑（用于 ListAvailableModels / getUsageLimits 等 API 调用）
 ///
 /// BuilderId 账号本地常见为 `profileArn=null`，但真实 IDE 抓包会带固定
 /// BuilderId profileArn；不带时上游会返回 `Invalid profileArn`。
 /// 因此这里对空 profileArn 降级到默认值（根据 provider）。
 ///
 /// ## 降级策略
-/// - Enterprise: 保持 None（Enterprise 不需要 profileArn）
+/// - Enterprise: 只用账号已保存的 profileArn（不套 BuilderId 默认）；缺失时由调用方
+///   通过 ListAvailableProfiles 发现
 /// - 其他 provider: 账号 profileArn → 默认 profileArn（根据 provider）
 pub fn resolve_profile_arn_with_fallback(
     account_profile_arn: Option<&str>,
@@ -167,7 +168,7 @@ pub fn resolve_profile_arn_with_fallback(
         .filter(|value| !value.is_empty());
 
     match provider {
-        Some("Enterprise") => None,
+        Some("Enterprise") => account_profile_arn.map(String::from),
         provider => account_profile_arn
             .map(String::from)
             .or_else(|| Some(resolve_default_profile_arn(provider).to_string())),
@@ -177,7 +178,7 @@ pub fn resolve_profile_arn_with_fallback(
 /// 统一解析带“优先候选”的 profileArn。
 ///
 /// 用于 token refresh 之后的调用：上游刷新结果返回的 profileArn 优先，其次账号保存值，
-/// 最后按 provider 降级到默认 profileArn；Enterprise 始终返回 None。
+/// 最后按 provider 降级到默认 profileArn；Enterprise 只用候选/账号值，不套默认 ARN。
 pub fn resolve_profile_arn_from_candidates(
     preferred_profile_arn: Option<&str>,
     account_profile_arn: Option<&str>,
@@ -222,7 +223,8 @@ pub fn find_account_by_id(
 ///
 /// 解析规则：
 /// - machine_id：账号自带（非空）→ 否则生成账号独立 ID
-/// - profile_arn：Enterprise → None；其他账号自带 → 否则 provider 默认 ARN
+/// - profile_arn：Enterprise → 账号已保存值（无则 None，由调用方 ListAvailableProfiles）；
+///   其他 → 账号自带 → 否则 provider 默认 ARN
 /// - region：profile_arn 解析出来的 region 优先 → 账号 region → fallback
 pub struct KiroCallContext {
     pub machine_id: String,
@@ -390,6 +392,20 @@ pub struct UsageResult {
     pub usage_data: serde_json::Value,
     pub is_banned: bool,
     pub is_auth_error: bool,
+    /// getUsageLimits 实际使用的 profileArn（Enterprise 可能由 ListAvailableProfiles 发现）
+    pub resolved_profile_arn: Option<String>,
+}
+
+impl UsageResult {
+    /// getUsageLimits 失败时的占位结果（仍允许落库账号）
+    pub fn empty() -> Self {
+        Self {
+            usage_data: serde_json::json!({}),
+            is_banned: false,
+            is_auth_error: false,
+            resolved_profile_arn: None,
+        }
+    }
 }
 
 /// 判断账号是否为 external_idp（微软 / Azure AD）。
@@ -546,12 +562,14 @@ async fn get_usage_by_account_inner(
     access_token: &str,
     use_account_proxy: bool,
 ) -> Result<UsageResult, String> {
-    use crate::clients::http_client::build_http_client_with_timeout_for_account;
+    use crate::clients::http_client::{
+        build_http_client_with_timeout_for_account, parse_region_from_profile_arn,
+    };
     use crate::clients::kiro_client::{usage_limits_region_candidates, KiroClient};
 
     let ctx = resolve_kiro_call_context(account, "us-east-1");
     let is_enterprise = account.provider.as_deref() == Some("Enterprise");
-    let regions = usage_limits_region_candidates(&ctx.region, is_enterprise);
+    let mut regions = usage_limits_region_candidates(&ctx.region, is_enterprise);
 
     let client = if use_account_proxy {
         KiroClient::from_client(build_http_client_with_timeout_for_account(account, 30, 10)?)
@@ -559,26 +577,51 @@ async fn get_usage_by_account_inner(
         KiroClient::new()?
     };
 
-    // getUsageLimits 不带 profileArn；企业号优先账号 region，再回退常见 region
+    // Enterprise：账号无 profileArn 时先 ListAvailableProfiles 发现真实 ARN（对齐 IDE）
+    let mut profile_arn = ctx.profile_arn;
+    if is_enterprise && profile_arn.is_none() {
+        match client
+            .resolve_enterprise_profile_arn(access_token, &regions)
+            .await
+        {
+            Ok(arn) => profile_arn = arn,
+            Err(e) => return parse_usage_result(Err(e), None),
+        }
+        if profile_arn.is_none() {
+            return Err(
+                "Enterprise 账号未解析到 profileArn（ListAvailableProfiles 为空）".to_string(),
+            );
+        }
+    }
+
+    // profileArn 内嵌 region 时优先该 region（避免先打错区）
+    if let Some(arn_region) = parse_region_from_profile_arn(profile_arn.as_deref()) {
+        regions = usage_limits_region_candidates(&arn_region, is_enterprise);
+    }
+
     let (used_region, usage_data) = match client
-        .get_usage_limits_with_region_fallback(access_token, &ctx.machine_id, &regions)
+        .get_usage_limits_with_region_fallback(
+            access_token,
+            &ctx.machine_id,
+            &regions,
+            profile_arn.as_deref(),
+        )
         .await
     {
         Ok(v) => v,
-        Err(e) => return parse_usage_result(Err(e)),
+        Err(e) => return parse_usage_result(Err(e), profile_arn),
     };
 
     // 某些封禁状态下 getUsageLimits 正常返回，但 ListAvailableModels 会 403
-    // Enterprise 的 profile_arn 为 None，跳过该探测
-    let mut result = parse_usage_result(Ok(usage_data))?;
+    let mut result = parse_usage_result(Ok(usage_data), profile_arn)?;
 
-    if !result.is_banned && ctx.profile_arn.is_some() {
+    if !result.is_banned && result.resolved_profile_arn.is_some() {
         match client
             .list_available_models(
                 access_token,
                 &ctx.machine_id,
                 &used_region,
-                ctx.profile_arn.as_deref(),
+                result.resolved_profile_arn.as_deref(),
             )
             .await
         {
@@ -625,23 +668,29 @@ pub async fn get_usage_by_provider_with_machine_id(
 }
 
 /// 解析 usage 结果，提取封禁状态和认证错误
-fn parse_usage_result(result: Result<serde_json::Value, String>) -> Result<UsageResult, String> {
+fn parse_usage_result(
+    result: Result<serde_json::Value, String>,
+    resolved_profile_arn: Option<String>,
+) -> Result<UsageResult, String> {
     match result {
         Ok(usage_data) => Ok(UsageResult {
             usage_data, // 直接使用 JSON Value
             is_banned: false,
             is_auth_error: false,
+            resolved_profile_arn,
         }),
         Err(e) if e.starts_with("BANNED:") => Ok(UsageResult {
             usage_data: serde_json::Value::Null,
             is_banned: true,
             is_auth_error: false,
+            resolved_profile_arn,
         }),
         // 401 或认证相关错误（包括 403 + token invalid）
         Err(e) if is_auth_error_message(&e) => Ok(UsageResult {
             usage_data: serde_json::Value::Null,
             is_banned: false,
             is_auth_error: true,
+            resolved_profile_arn,
         }),
         // 其他错误直接抛出
         Err(e) => Err(e),
@@ -952,12 +1001,21 @@ mod tests {
     }
 
     #[test]
-    fn resolve_profile_arn_with_fallback_omits_enterprise_profile_arn() {
+    fn resolve_profile_arn_with_fallback_keeps_enterprise_account_arn_without_default() {
         assert_eq!(
             resolve_profile_arn_with_fallback(
-                Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/IGNORED"),
+                Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/AAAACCCCXXXX"),
                 Some("Enterprise"),
-            ),
+            )
+            .as_deref(),
+            Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/AAAACCCCXXXX")
+        );
+        assert_eq!(
+            resolve_profile_arn_with_fallback(None, Some("Enterprise")),
+            None
+        );
+        assert_eq!(
+            resolve_profile_arn_with_fallback(Some("   "), Some("Enterprise")),
             None
         );
     }
@@ -989,13 +1047,18 @@ mod tests {
     }
 
     #[test]
-    fn resolve_profile_arn_from_candidates_omits_enterprise_even_with_candidates() {
+    fn resolve_profile_arn_from_candidates_keeps_enterprise_candidates_without_default() {
         assert_eq!(
             resolve_profile_arn_from_candidates(
                 Some("arn:aws:codewhisperer:us-west-2:123456789012:profile/REFRESHED"),
                 Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/ACCOUNT"),
                 Some("Enterprise"),
-            ),
+            )
+            .as_deref(),
+            Some("arn:aws:codewhisperer:us-west-2:123456789012:profile/REFRESHED")
+        );
+        assert_eq!(
+            resolve_profile_arn_from_candidates(None, None, Some("Enterprise")),
             None
         );
     }
@@ -1046,12 +1109,13 @@ mod tests {
 
     #[test]
     fn parse_usage_result_maps_banned_and_auth_errors_without_failing() {
-        let banned = parse_usage_result(Err("BANNED: blocked".to_string())).unwrap();
+        let banned = parse_usage_result(Err("BANNED: blocked".to_string()), None).unwrap();
         assert!(banned.is_banned);
         assert!(!banned.is_auth_error);
         assert_eq!(banned.usage_data, serde_json::Value::Null);
 
-        let auth_error = parse_usage_result(Err("AUTH_ERROR: token expired".to_string())).unwrap();
+        let auth_error =
+            parse_usage_result(Err("AUTH_ERROR: token expired".to_string()), None).unwrap();
         assert!(!auth_error.is_banned);
         assert!(auth_error.is_auth_error);
         assert_eq!(auth_error.usage_data, serde_json::Value::Null);

--- a/src-tauri/src/gateway/proxy.rs
+++ b/src-tauri/src/gateway/proxy.rs
@@ -2662,13 +2662,19 @@ async fn call_generate_assistant_response<T: serde::Serialize + ?Sized>(
     loop {
         attempt += 1;
 
+        // Enterprise / 有真实 ARN 时必须带头：上游 runtime（含 MCP 相关调用）会校验
+        let include_profile_arn = upstream
+            .profile_arn
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty());
         let upstream_resp = add_kiro_upstream_headers(
             upstream.http.post(&upstream_url),
             upstream,
             "application/vnd.amazon.eventstream",
             true,
             true,
-            false,
+            include_profile_arn,
         )
         .json(upstream_payload)
         .send()
@@ -3025,7 +3031,7 @@ async fn resolve_managed_account_credentials(
                         ));
                     }
                 };
-                return Ok(UpstreamCredentials {
+                let creds = UpstreamCredentials {
                     account_id: account.id.clone(),
                     access_token: access_token.clone(),
                     machine_id: ctx.machine_id.clone(),
@@ -3038,7 +3044,8 @@ async fn resolve_managed_account_credentials(
                     auth_method: account.auth_method.clone(),
                     send_opt_out: should_send_codewhisperer_optout(),
                     http,
-                });
+                };
+                return ensure_enterprise_profile_arn(&account, creds).await;
             }
         }
     }
@@ -3049,11 +3056,13 @@ async fn resolve_managed_account_credentials(
             let mut usage_data = None;
             let mut is_banned = false;
             let mut is_auth_error = false;
+            let mut resolved_profile_arn = None;
 
             if let Ok(usage) = usage_result {
                 usage_data = Some(usage.usage_data);
                 is_banned = usage.is_banned;
                 is_auth_error = usage.is_auth_error;
+                resolved_profile_arn = usage.resolved_profile_arn;
             }
 
             // 失败追踪：如果账号被封禁或认证失败，累加失败计数
@@ -3067,6 +3076,9 @@ async fn resolve_managed_account_credentials(
                 is_auth_error,
                 should_increment_failure,
             );
+            if let Some(ref arn) = resolved_profile_arn {
+                persist_account_profile_arn(&account.id, arn);
+            }
 
             // 减少连接计数
             state.load_balancer.decrement_connections(&account.id).await;
@@ -3100,7 +3112,12 @@ async fn resolve_managed_account_credentials(
                 .record_success(&account.id, response_time_ms)
                 .await;
 
-            build_upstream_credentials_from_refresh(config, &account, refresh)
+            let mut account_for_creds = account.clone();
+            if let Some(arn) = resolved_profile_arn {
+                account_for_creds.profile_arn = Some(arn);
+            }
+            let creds = build_upstream_credentials_from_refresh(config, &account_for_creds, refresh)?;
+            ensure_enterprise_profile_arn(&account_for_creds, creds).await
         }
         Err(error) => {
             // 减少连接计数
@@ -3146,11 +3163,13 @@ async fn force_refresh_upstream_credentials(
     let mut usage_data = None;
     let mut is_banned = false;
     let mut is_auth_error = false;
+    let mut resolved_profile_arn = None;
 
     if let Ok(usage) = usage_result {
         usage_data = Some(usage.usage_data);
         is_banned = usage.is_banned;
         is_auth_error = usage.is_auth_error;
+        resolved_profile_arn = usage.resolved_profile_arn;
     }
 
     persist_account_refresh(
@@ -3161,6 +3180,9 @@ async fn force_refresh_upstream_credentials(
         is_auth_error,
         is_banned || is_auth_error,
     );
+    if let Some(ref arn) = resolved_profile_arn {
+        persist_account_profile_arn(&account.id, arn);
+    }
 
     if is_banned || is_auth_error {
         state.load_balancer.record_failure(&account.id).await;
@@ -3175,7 +3197,12 @@ async fn force_refresh_upstream_credentials(
         }
     }
 
-    build_upstream_credentials_from_refresh(config, &account, refresh)
+    let mut account_for_creds = account.clone();
+    if let Some(arn) = resolved_profile_arn {
+        account_for_creds.profile_arn = Some(arn);
+    }
+    let creds = build_upstream_credentials_from_refresh(config, &account_for_creds, refresh)?;
+    ensure_enterprise_profile_arn(&account_for_creds, creds).await
 }
 
 fn build_upstream_credentials_from_refresh(
@@ -3218,8 +3245,64 @@ fn build_upstream_credentials_from_refresh(
         http,
     })
 }
-/// 根据账号 provider 返回默认的 profileArn
-/// BuilderId 账号和 Social 账号（Github/Google）使用不同的 profileArn
+
+/// Enterprise 上游调用必须有真实 profileArn：账号已存优先，否则 ListAvailableProfiles 发现并落库。
+async fn ensure_enterprise_profile_arn(
+    account: &Account,
+    mut creds: UpstreamCredentials,
+) -> Result<UpstreamCredentials, String> {
+    let has_arn = creds
+        .profile_arn
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
+    if has_arn {
+        return Ok(creds);
+    }
+    if account.provider.as_deref() != Some("Enterprise") {
+        return Ok(creds);
+    }
+
+    use crate::clients::kiro_client::{usage_limits_region_candidates, KiroClient};
+
+    let client = KiroClient::from_client(creds.http.clone());
+    let regions = usage_limits_region_candidates(&creds.region, true);
+    let arn = client
+        .resolve_enterprise_profile_arn(&creds.access_token, &regions)
+        .await?
+        .ok_or_else(|| {
+            format!(
+                "Enterprise 账号 {} 未解析到 profileArn（ListAvailableProfiles 为空）",
+                account.label
+            )
+        })?;
+
+    persist_account_profile_arn(&account.id, &arn);
+    log::info!(
+        "[网关] Enterprise 账号 {} 解析到 profileArn: {}",
+        account.label,
+        arn
+    );
+    creds.profile_arn = Some(arn.clone());
+    creds.available_models_profile_arn = Some(arn);
+    Ok(creds)
+}
+
+fn persist_account_profile_arn(account_id: &str, profile_arn: &str) {
+    let mut store = AccountStore::new();
+    if let Some(account) = store.accounts.iter_mut().find(|a| a.id == account_id) {
+        let empty = account
+            .profile_arn
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .is_empty();
+        if empty || account.profile_arn.as_deref() != Some(profile_arn) {
+            account.profile_arn = Some(profile_arn.to_string());
+            let _ = store.save_to_file();
+        }
+    }
+}
 
 fn format_managed_upstream_source(config: &GatewayConfig, account: &Account) -> String {
     let account_label = account
@@ -6306,6 +6389,53 @@ mod tests {
             Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/test")
         );
         assert!(request.headers().get("redirect-for-internal").is_none());
+    }
+
+    #[test]
+    fn add_kiro_upstream_headers_adds_profile_arn_for_enterprise_generate() {
+        let upstream = UpstreamCredentials {
+            account_id: "ent-account".to_string(),
+            access_token: "token-ent".to_string(),
+            machine_id: "machine-ent".to_string(),
+            profile_arn: Some(
+                "arn:aws:codewhisperer:us-east-1:123456789012:profile/AAAACCCCXXXX".to_string(),
+            ),
+            available_models_profile_arn: Some(
+                "arn:aws:codewhisperer:us-east-1:123456789012:profile/AAAACCCCXXXX".to_string(),
+            ),
+            provider: Some("Enterprise".to_string()),
+            region: "us-east-1".to_string(),
+            source_label: "single:ent".to_string(),
+            user_agent: "KiroIDE 0.11.34 machine-ent".to_string(),
+            auth_method: Some("IdC".to_string()),
+            send_opt_out: true,
+            http: reqwest::Client::new(),
+        };
+
+        let include_profile_arn = upstream
+            .profile_arn
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty());
+        let request = add_kiro_upstream_headers(
+            reqwest::Client::new()
+                .post("https://runtime.us-east-1.kiro.dev/generateAssistantResponse"),
+            &upstream,
+            "application/vnd.amazon.eventstream",
+            true,
+            true,
+            include_profile_arn,
+        )
+        .build()
+        .expect("request should build");
+
+        assert_eq!(
+            request
+                .headers()
+                .get("x-amzn-kiro-profile-arn")
+                .and_then(|value| value.to_str().ok()),
+            Some("arn:aws:codewhisperer:us-east-1:123456789012:profile/AAAACCCCXXXX")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

修复 Enterprise 账号 `getUsageLimits` 返回 `Invalid profileArn`、无法拉取用量的问题。

#149 正确地避免了企业号套用 BuilderId 默认 `profileArn`（这确实会 400/403），但把「错误 ARN」误判成了「不能传 ARN」。实测对齐 Kiro IDE 后：

- **不带** `profileArn` → 400 `Invalid profileArn`
- **带错的**（BuilderId 默认）→ 400/403
- **先 `ListAvailableProfiles` 再带真实 ARN** → 200，可正常返回用量与 `userInfo`

本 PR 在统一 usage 路径上恢复「发现真实 profileArn → 再查配额」，并落库，避免每次都探测。

关联：#149 #136 #113

## 改动要点

- Enterprise：无本地 `profileArn` 时先 `ListAvailableProfiles`，再用返回 ARN 调 `getUsageLimits`
- Enterprise：**绝不**回退到 BuilderId 默认 ARN（延续 #113 / #149 的正确约束）
- 成功后把 `profileArn` / email / userId 写回账号
- 保留企业号 region 回退（账号 region → us-east-1 / eu-central-1）

## Test plan

- [ ] Enterprise IdC 登录后刷新配额：不再出现 `Invalid profileArn`
- [ ] 用量、email、userId 能显示；`profileArn` 被保存
- [ ] BuilderId / Social 刷新配额仍正常
- [ ] 二次刷新走已保存 `profileArn`，不必每次 ListAvailableProfiles

## References

- 真实 IDE：`GetUsageLimitsCommand` 始终携带企业 profileArn
- #149 对齐的 kiro.rs「REST GET 不带 profileArn」与 IDE 抓包不一致；根因应是「勿传错误 ARN」，而非「完全不传」